### PR TITLE
hack unused-value warning on POP() to pass build

### DIFF
--- a/include/wren.h
+++ b/include/wren.h
@@ -2,6 +2,7 @@
 #define wren_h
 
 #include <stdlib.h>
+#include <stdint.h>
 
 typedef struct WrenVM WrenVM;
 

--- a/src/wren_vm.c
+++ b/src/wren_vm.c
@@ -510,8 +510,8 @@ static bool runInterpreter(WrenVM* vm)
 
   Code instruction;
   INTERPRET_LOOP
-  {
-    CASE_CODE(POP): POP(); DISPATCH();
+  { // cast POP() to void to get rid of unused-value warning
+    CASE_CODE(POP): (void) POP(); DISPATCH();
 
     CASE_CODE(NULL):  PUSH(NULL_VAL); DISPATCH();
     CASE_CODE(FALSE): PUSH(FALSE_VAL); DISPATCH();
@@ -811,7 +811,7 @@ static bool runInterpreter(WrenVM* vm)
       else
       {
         // Discard the condition and evaluate the right hand side.
-        POP();
+        (void) POP();
       }
       DISPATCH();
     }
@@ -824,7 +824,7 @@ static bool runInterpreter(WrenVM* vm)
       if (IS_FALSE(condition) || IS_NULL(condition))
       {
         // Discard the condition and evaluate the right hand side.
-        POP();
+        (void) POP();
       }
       else
       {
@@ -863,7 +863,7 @@ static bool runInterpreter(WrenVM* vm)
 
     CASE_CODE(CLOSE_UPVALUE):
       closeUpvalue(fiber);
-      POP();
+      (void) POP();
       DISPATCH();
 
     CASE_CODE(NEW):
@@ -873,7 +873,7 @@ static bool runInterpreter(WrenVM* vm)
       // allocated so that it doesn't get collected.
       ObjClass* classObj = AS_CLASS(PEEK());
       Value instance = wrenNewInstance(vm, classObj);
-      POP();
+      (void) POP();
       PUSH(instance);
       DISPATCH();
     }
@@ -999,8 +999,8 @@ static bool runInterpreter(WrenVM* vm)
       
       // Don't pop the superclass and name off the stack until the subclass is
       // done being created, to make sure it doesn't get collected.
-      POP();
-      POP();
+      (void) POP();
+      (void) POP();
 
       PUSH(OBJ_VAL(classObj));
       DISPATCH();
@@ -1014,8 +1014,8 @@ static bool runInterpreter(WrenVM* vm)
       ObjClass* classObj = AS_CLASS(PEEK());
       Value method = PEEK2();
       bindMethod(vm, type, symbol, classObj, method);
-      POP();
-      POP();
+      (void) POP();
+      (void) POP();
       DISPATCH();
     }
 


### PR DESCRIPTION
I'd like to build wren and play around it but encountered two problems, this PR makes me pass the build :-)

The first error is "src/wren_utils.h:50:22: error: unknown type name 'uint8_t'", which is fixed by adding the stdint.h header.

The second one is actually an unused-value warning but turns to error due to the -Werror CFLAGS in Makefile. It's caused by several calls to POP() without using its value. My workaroud is based on [GCC documentation](http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html):

> -Wunused-value
> ...To suppress this warning cast the unused expression to ‘void’. This includes an expression-statement or the left-hand side of a comma expression that contains no side effects. For example, an expression such as ‘x[i,j]’ causes a warning, while ‘x[(void)i,j]’ does not.
