### PR TITLE
Concat operator, tests. Now [1,2,3] + (4..6) works!

### DIFF
--- a/builtin/core.wren
+++ b/builtin/core.wren
@@ -8,4 +8,19 @@ class List {
     result = result + "]"
     return result
   }
+
+  + that {
+    var newList = []
+    if (this.count > 0) {
+      for (element in this) {
+        newList.add(element)
+      }
+    }
+    if (that is Range || that.count > 0) {
+      for (element in that) {
+        newList.add(element)
+      }
+    }
+    return newList
+  }
 }

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -51,6 +51,21 @@ static const char* libSource =
 "    result = result + \"]\"\n"
 "    return result\n"
 "  }\n"
+"\n"
+"  + that {\n"
+"    var newList = []\n"
+"    if (this.count > 0) {\n"
+"      for (element in this) {\n"
+"        newList.add(element)\n"
+"      }\n"
+"    }\n"
+"    if (that is Range || that.count > 0) {\n"
+"      for (element in that) {\n"
+"        newList.add(element)\n"
+"      }\n"
+"    }\n"
+"    return newList\n"
+"  }\n"
 "}\n";
 
 // Validates that the given argument in [args] is a Num. Returns true if it is.

--- a/test/list/concat.wren
+++ b/test/list/concat.wren
@@ -1,0 +1,15 @@
+var a = [1, 2, 3]
+var b = [4, 5, 6]
+var c = a + b
+var d = a + (4..6)
+var e = a + []
+var f = [] + a
+var g = [] + []
+
+IO.print(a) // expect: [1, 2, 3]
+IO.print(b) // expect: [4, 5, 6]
+IO.print(c) // expect: [1, 2, 3, 4, 5, 6]
+IO.print(d) // expect: [1, 2, 3, 4, 5, 6]
+IO.print(e) // expect: [1, 2, 3]
+IO.print(f) // expect: [1, 2, 3]
+IO.print(g) // expect: []


### PR DESCRIPTION
Fourth try. ;)

Concat operator, tests. Now [1,2,3] + (4..6) works! Inlined helper functions to keep core lib small.

I could not get `this[0..-1]` to work for copying, so I inlined the method I had before.

Can develop be kept updated to master? When I added a feature branch (automatically, so my fault), it inadvertently was based on develop.
