### PR TITLE
Remove spaces before arguments in core.wren

### DIFF
--- a/builtin/core.wren
+++ b/builtin/core.wren
@@ -1,5 +1,5 @@
 class Sequence {
-  map (f) {
+  map(f) {
     var result = []
     for (element in this) {
       result.add(f.call(element))
@@ -7,7 +7,7 @@ class Sequence {
     return result
   }
 
-  where (f) {
+  where(f) {
     var result = []
     for (element in this) {
       if (f.call(element)) result.add(element)

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -42,7 +42,7 @@
 // This string literal is generated automatically from core. Do not edit.
 static const char* libSource =
 "class Sequence {\n"
-"  map (f) {\n"
+"  map(f) {\n"
 "    var result = []\n"
 "    for (element in this) {\n"
 "      result.add(f.call(element))\n"
@@ -50,7 +50,7 @@ static const char* libSource =
 "    return result\n"
 "  }\n"
 "\n"
-"  where (f) {\n"
+"  where(f) {\n"
 "    var result = []\n"
 "    for (element in this) {\n"
 "      if (f.call(element)) result.add(element)\n"


### PR DESCRIPTION
I had been writing methods with spaces before the arguments, but that doesn't seem to be the case in the documentation. This is just to keep things consistent.

Bike shedding, I guess.
