### PR TITLE
Include the receiver name in methodNotFound error messages.

### DIFF
--- a/src/wren_vm.c
+++ b/src/wren_vm.c
@@ -328,7 +328,7 @@ static void methodNotFound(WrenVM* vm, ObjFiber* fiber, int symbol, ObjClass* cl
 {
   char message[100];
 
-  snprintf(message, 100, "Receiver '%s' does not implement method '%s'.",
+  snprintf(message, 100, "%s does not implement method '%s'.",
            classObj->name->value,
            vm->methods.names.data[symbol]);
 

--- a/test/inheritance/do_not_inherit_static_methods.wren
+++ b/test/inheritance/do_not_inherit_static_methods.wren
@@ -4,4 +4,4 @@ class Foo {
 
 class Bar is Foo {}
 
-Bar.methodOnFoo // expect runtime error: Receiver does not implement method 'methodOnFoo'.
+Bar.methodOnFoo // expect runtime error: Bar metaclass does not implement method 'methodOnFoo'.

--- a/test/method/not_found.wren
+++ b/test/method/not_found.wren
@@ -1,3 +1,3 @@
 class Foo {}
 
-(new Foo).someUnknownMethod // expect runtime error: Receiver does not implement method 'someUnknownMethod'.
+(new Foo).someUnknownMethod // expect runtime error: Foo does not implement method 'someUnknownMethod'.

--- a/test/method/static_method_not_found.wren
+++ b/test/method/static_method_not_found.wren
@@ -1,0 +1,3 @@
+class Foo {}
+
+Foo.bar // expect runtime error: Foo metaclass does not implement method 'bar'.


### PR DESCRIPTION
Example:

```
> class Foo {}
> Foo.baz
Receiver 'Foo metaclass', does not implement method 'baz'.
```

Note 'metaclass' in the error message. Not sure where to go for that one. Perhaps it should call the wren-level name method against the classObj instead of using the struct to get the name?
