### PR TITLE
Make tab(\t) a valid whitespace character.

### DIFF
--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -789,6 +789,7 @@ static void nextToken(Parser* parser)
         makeToken(parser, TOKEN_LINE);
         return;
 
+      case '\t':
       case ' ':
         // Skip forward until we run out of whitespace.
         while (peekChar(parser) == ' ') nextChar(parser);

--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -792,7 +792,7 @@ static void nextToken(Parser* parser)
       case '\t':
       case ' ':
         // Skip forward until we run out of whitespace.
-        while (peekChar(parser) == ' ') nextChar(parser);
+        while (peekChar(parser) == ' ' || peekChar(parser) == '\t') nextChar(parser);
         break;
 
       case '"': readString(parser); return;

--- a/test/whitespace.wren
+++ b/test/whitespace.wren
@@ -1,0 +1,17 @@
+// No indent
+IO.print("ok") // expect: ok
+
+// Indent with space
+  IO.print("ok") // expect: ok
+
+// Indent with tab
+	IO.print("ok") // expect: ok
+
+// Indent with space then tab
+  	IO.print("ok") // expect: ok
+
+// Indent with tab then space
+	  IO.print("ok") // expect: ok
+
+// Indent with mixed tab and space
+  	  	IO.print("ok") // expect: ok

--- a/test/whitespace.wren
+++ b/test/whitespace.wren
@@ -15,3 +15,12 @@ IO.print("ok") // expect: ok
 
 // Indent with mixed tab and space
   	  	IO.print("ok") // expect: ok
+
+// Space in with code
+IO . print ( "ok" ) // expect: ok
+
+// Tab in with code
+IO	.	print	(	"ok"	) // expect: ok
+
+// Tab and space mixed in with code
+IO	 . 	print 	(	 "ok" 	) // expect: ok


### PR DESCRIPTION
Some prefer to use tab for indentation.