### PR TITLE
Makefile fixes for Linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@
 CFLAGS := -std=c99 -Wall -Werror
 # TODO: Add -Wextra.
 
-DEBUG_CFLAGS := -O0 -DDEBUG
-RELEASE_CFLAGS := -Os
-
 # Files.
 SOURCES := $(wildcard src/*.c)
 HEADERS := $(wildcard src/*.h)
@@ -27,23 +24,27 @@ prep:
 debug: prep wrend
 
 # Debug command-line interpreter.
+wrend: CFLAGS += -O0 -DDEBUG
+
 wrend: $(DEBUG_OBJECTS)
-	$(CC) $(CFLAGS) $(DEBUG_CFLAGS) -Iinclude -o wrend $^ -lm
+	$(CC) $(CFLAGS) -Iinclude -o wrend $^ -lm
 
 # Debug object files.
 build/debug/%.o: src/%.c include/wren.h $(HEADERS)
-	$(CC) -c $(CFLAGS) $(DEBUG_CFLAGS) -Iinclude -o $@ $<
+	$(CC) -c $(CFLAGS) -Iinclude -o $@ $<
 
 # Release build.
 release: prep wren
 
 # Release command-line interpreter.
+wren: CFLAGS += -Os
+
 wren: $(RELEASE_OBJECTS)
-	$(CC) $(CFLAGS) $(RELEASE_CFLAGS) -Iinclude -o wren $^ -lm
+	$(CC) $(CFLAGS) -Iinclude -o wren $^ -lm
 
 # Release object files.
 build/release/%.o: src/%.c include/wren.h $(HEADERS)
-	$(CC) -c $(CFLAGS) $(RELEASE_CFLAGS) -Iinclude -o $@ $<
+	$(CC) -c $(CFLAGS) -Iinclude -o $@ $<
 
 # Run the tests against the debug build of Wren.
 test: debug

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 # Compiler flags.
-CFLAGS = -std=c99 -Wall -Werror
+CFLAGS := -std=c99 -Wall -Werror
 # TODO: Add -Wextra.
-DEBUG_CFLAGS = -O0 -DDEBUG
-RELEASE_CFLAGS = -Os
+
+DEBUG_CFLAGS := -O0 -DDEBUG
+RELEASE_CFLAGS := -Os
 
 # Files.
-SOURCES = $(wildcard src/*.c)
-HEADERS = $(wildcard src/*.h)
-OBJECTS = $(SOURCES:.c=.o)
+SOURCES := $(wildcard src/*.c)
+HEADERS := $(wildcard src/*.h)
+OBJECTS := $(SOURCES:.c=.o)
 
-DEBUG_OBJECTS = $(addprefix build/debug/, $(notdir $(OBJECTS)))
-RELEASE_OBJECTS = $(addprefix build/release/, $(notdir $(OBJECTS)))
+DEBUG_OBJECTS := $(addprefix build/debug/, $(notdir $(OBJECTS)))
+RELEASE_OBJECTS := $(addprefix build/release/, $(notdir $(OBJECTS)))
 
 .PHONY: all clean test builtin docs watchdocs
 


### PR DESCRIPTION
The main commit is the first one, as wren doesn't build out of the box for me:
```
% make -j1
cc -c -std=c99 -Wall -Werror -Os -Iinclude -o build/release/wren_compiler.o src/wren_compiler.c
cc1: warnings being treated as errors
In file included from src/wren_compiler.h:5,
                 from src/wren_compiler.c:8:
src/wren_value.h:293: error: declaration does not declare anything
make: *** [build/release/wren_compiler.o] Error 1
```
This is due to using strict `c99` which, at least with g++ 4.4 used above, disables support for unnamed unions
as it's not in C99 (but apparently in C11, according to https://gcc.gnu.org/onlinedocs/gcc/Unnamed-Fields.html).

My fix allows to use `make CC=gcc` to avoid this, but this is still not ideal as it's still broken out of the box. Detecting
gcc from makefile is rather ugly though, so I don't know if you're willing to do it.

The two subsequent ones just clean up the makefile a little.