### PR TITLE
Don't try to run an empty line in the REPL.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -90,8 +90,12 @@ static int runRepl(WrenVM* vm)
       return 0;
     }
 
-    // TODO: Handle failure.
-    wrenInterpret(vm, "Prompt", line);
+    // Do nothing if we received an empty line.
+    if (strcmp(line, "\n") != 0)
+    {
+      // TODO: Handle failure.
+      wrenInterpret(vm, "Prompt", line);
+    }
 
     free(line);
 


### PR DESCRIPTION
This PR prevents the REPL from trying to interpret an empty line (a behaviour that is similar to most other REPLs).