### PR TITLE
Fixing CRLF problem on Windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -39,7 +39,8 @@ static char* readFile(const char* path)
 
   // Read the entire file.
   size_t bytesRead = fread(buffer, sizeof(char), fileSize, file);
-  failIf(bytesRead < fileSize, 74, "Could not read file \"%s\".\n", path);
+  size_t filePos = ftell(file);
+  failIf(filePos < fileSize, 74, "Could not read file \"%s\".\n", path);
 
   // Terminate the string.
   buffer[bytesRead] = '\0';


### PR DESCRIPTION
On Windows newline is represented as CRLF ('\r\n').

When file is open in "r' (not "rb") mode, the `\r`s are omitted and `fread` returns number of actual bytes read which might be smaller than file size.

In this case validation in the wren code will fail.

This patch changes the way validation is done to prevent the problem without complicating lexer.