### PR TITLE
Adding support for '\r' char to lexer.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,7 @@ static void failIf(bool condition, int exitCode, const char* format, ...)
 
 static char* readFile(const char* path)
 {
-  FILE* file = fopen(path, "r");
+  FILE* file = fopen(path, "rb");
   failIf(file == NULL, 66, "Could not open file \"%s\".\n", path);
 
   // Find out how big the file is.

--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -781,16 +781,14 @@ static void nextToken(Parser* parser)
         twoCharToken(parser, '=', TOKEN_BANGEQ, TOKEN_BANG);
         return;
 
-      case '\r':
-         twoCharToken(parser, '\n', TOKEN_LINE, TOKEN_LINE);
-         return;
       case '\n':
         makeToken(parser, TOKEN_LINE);
         return;
 
       case ' ':
+      case '\r':
         // Skip forward until we run out of whitespace.
-        while (peekChar(parser) == ' ') nextChar(parser);
+        while (peekChar(parser) == ' ' || peekChar(parser) == '\r') nextChar(parser);
         break;
 
       case '"': readString(parser); return;

--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -781,6 +781,9 @@ static void nextToken(Parser* parser)
         twoCharToken(parser, '=', TOKEN_BANGEQ, TOKEN_BANG);
         return;
 
+      case '\r':
+         twoCharToken(parser, '\n', TOKEN_LINE, TOKEN_LINE);
+         return;
       case '\n':
         makeToken(parser, TOKEN_LINE);
         return;


### PR DESCRIPTION
Another way to fix same issue: opening script file in binary mode and handling `\r` as a new line character (both followed with `\n` as in Windows or standalone as in old Macs - just in case =))