### PR TITLE
Let the user know the arity of a missing method in the error message.

### DIFF
--- a/src/wren_vm.c
+++ b/src/wren_vm.c
@@ -24,6 +24,39 @@ static void* defaultReallocate(void* memory, size_t oldSize, size_t newSize)
   return realloc(memory, newSize);
 }
 
+// Returns the canonical name of a symbol with the argument spaces stripped off.
+char* canonicalSymbol(char* symbolName)
+{
+  // Find the end of the text in the given symbol name.
+  int pos = strlen(symbolName) - 1;
+  while (symbolName[pos] == ' ') pos--;
+
+  // Create a new string that contains only the symbol name.
+  char *canonicalizedSymbol = malloc(pos + 1);
+  strncpy(canonicalizedSymbol, symbolName, pos + 1);
+
+  return canonicalizedSymbol;
+}
+
+// Extracts the number of arguments from a symbol name.
+char* methodArgumentsString(char* symbolName)
+{
+  // Count the number of spaces to determine number of arguments for this
+  // symbol.
+  int pos = strlen(symbolName) - 1;
+  while (symbolName[pos] == ' ') pos--;
+
+  int args = strlen(symbolName) - pos - 1;
+
+  if (args == 1) return "1 argument";
+
+  int stringSize = args > 9 ? 13 : 12;
+  char* argumentString = malloc(stringSize);
+  snprintf(argumentString, stringSize, "%d arguments", args);
+
+  return argumentString;
+}
+
 WrenVM* wrenNewVM(WrenConfiguration* configuration)
 {
   WrenReallocateFn reallocate = defaultReallocate;
@@ -576,9 +609,10 @@ static bool runInterpreter(WrenVM* vm)
       if (symbol >= classObj->methods.count)
       {
         char message[100];
-        snprintf(message, 100, "%s does not implement method '%s'.",
+        snprintf(message, 100, "%s does not implement method '%s' with %s.",
                  classObj->name->value,
-                 vm->methodNames.data[symbol]);
+                 canonicalSymbol(vm->methodNames.data[symbol]),
+                 methodArgumentsString(vm->methodNames.data[symbol]));
         RUNTIME_ERROR(message);
       }
 
@@ -629,9 +663,10 @@ static bool runInterpreter(WrenVM* vm)
         case METHOD_NONE:
         {
           char message[100];
-          snprintf(message, 100, "%s does not implement method '%s'.",
-                   classObj->name->value,
-                   vm->methodNames.data[symbol]);
+          snprintf(message, 100, "%s does not implement method '%s' with %s.",
+                 classObj->name->value,
+                 canonicalSymbol(vm->methodNames.data[symbol]),
+                 methodArgumentsString(vm->methodNames.data[symbol]));
           RUNTIME_ERROR(message);
         }
       }
@@ -680,8 +715,10 @@ static bool runInterpreter(WrenVM* vm)
       if (symbol >= classObj->methods.count)
       {
         char message[100];
-        snprintf(message, 100, "%s does not implement method '%s'.",
-                 classObj->name->value, vm->methodNames.data[symbol]);
+        snprintf(message, 100, "%s does not implement method '%s' with %s.",
+                 classObj->name->value,
+                 canonicalSymbol(vm->methodNames.data[symbol]),
+                 methodArgumentsString(vm->methodNames.data[symbol]));
         RUNTIME_ERROR(message);
       }
 
@@ -732,8 +769,10 @@ static bool runInterpreter(WrenVM* vm)
         case METHOD_NONE:
         {
           char message[100];
-          snprintf(message, 100, "%s does not implement method '%s'.",
-                   classObj->name->value, vm->methodNames.data[symbol]);
+          snprintf(message, 100, "%s does not implement method '%s' with %s.",
+                 classObj->name->value,
+                 canonicalSymbol(vm->methodNames.data[symbol]),
+                 methodArgumentsString(vm->methodNames.data[symbol]));
           RUNTIME_ERROR(message);
         }
       }

--- a/test/fiber/error.wren
+++ b/test/fiber/error.wren
@@ -3,5 +3,5 @@ var fiber = new Fiber {
 }
 
 IO.print(fiber.error) // expect: null
-IO.print(fiber.try)   // expect: String does not implement method 'unknown'.
-IO.print(fiber.error) // expect: String does not implement method 'unknown'.
+IO.print(fiber.try)   // expect: String does not implement method 'unknown' with 0 arguments.
+IO.print(fiber.error) // expect: String does not implement method 'unknown' with 0 arguments.

--- a/test/fiber/try.wren
+++ b/test/fiber/try.wren
@@ -6,5 +6,5 @@ var fiber = new Fiber {
 
 IO.print(fiber.try)
 // expect: before
-// expect: Bool does not implement method 'unknownMethod'.
+// expect: Bool does not implement method 'unknownMethod' with 0 arguments.
 IO.print("after try") // expect: after try

--- a/test/inheritance/do_not_inherit_static_methods.wren
+++ b/test/inheritance/do_not_inherit_static_methods.wren
@@ -4,4 +4,4 @@ class Foo {
 
 class Bar is Foo {}
 
-Bar.methodOnFoo // expect runtime error: Bar metaclass does not implement method 'methodOnFoo'.
+Bar.methodOnFoo // expect runtime error: Bar metaclass does not implement method 'methodOnFoo' with 0 arguments.

--- a/test/method/not_found.wren
+++ b/test/method/not_found.wren
@@ -1,3 +1,3 @@
 class Foo {}
 
-(new Foo).someUnknownMethod // expect runtime error: Foo does not implement method 'someUnknownMethod'.
+(new Foo).someUnknownMethod // expect runtime error: Foo does not implement method 'someUnknownMethod' with 0 arguments.

--- a/test/method/not_found_eleven_arguments.wren
+++ b/test/method/not_found_eleven_arguments.wren
@@ -1,0 +1,3 @@
+class Foo {}
+
+(new Foo).someUnknownMethod(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11) // expect runtime error: Foo does not implement method 'someUnknownMethod' with 11 arguments.

--- a/test/method/not_found_multiple_arguments.wren
+++ b/test/method/not_found_multiple_arguments.wren
@@ -1,0 +1,3 @@
+class Foo {}
+
+(new Foo).someUnknownMethod(1, 2) // expect runtime error: Foo does not implement method 'someUnknownMethod' with 2 arguments.

--- a/test/method/not_found_one_argument.wren
+++ b/test/method/not_found_one_argument.wren
@@ -1,0 +1,3 @@
+class Foo {}
+
+(new Foo).someUnknownMethod(1) // expect runtime error: Foo does not implement method 'someUnknownMethod' with 1 argument.

--- a/test/method/static_method_not_found.wren
+++ b/test/method/static_method_not_found.wren
@@ -1,3 +1,3 @@
 class Foo {}
 
-Foo.bar // expect runtime error: Foo metaclass does not implement method 'bar'.
+Foo.bar // expect runtime error: Foo metaclass does not implement method 'bar' with 0 arguments.

--- a/test/super/no_superclass_method.wren
+++ b/test/super/no_superclass_method.wren
@@ -1,7 +1,7 @@
 class Base {}
 
 class Derived is Base {
-  foo { super.doesNotExist } // expect runtime error: Base does not implement method 'doesNotExist'.
+  foo { super.doesNotExist } // expect runtime error: Base does not implement method 'doesNotExist' with 0 arguments.
 }
 
 (new Derived).foo


### PR DESCRIPTION
Since the arity of a function is expressed with a number of spaces after the function name it can be a little be difficult to quickly see that you used an incorrect number of arguments. This PR updates the error message to include the number of arguments that the user tried to use but wasn't implemented.