### PR TITLE
Use versioned Python binary

### DIFF
--- a/script/generate_builtins.py
+++ b/script/generate_builtins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import glob
 import os.path
 import re

--- a/script/generate_docs.py
+++ b/script/generate_docs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import glob
 import markdown

--- a/script/metrics.py
+++ b/script/metrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import glob
 import fnmatch

--- a/script/test.py
+++ b/script/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 from collections import defaultdict
 from os import listdir


### PR DESCRIPTION
I'm running Arch Linux, where /usr/bin/python is Python 3.
This solution is suggested by PEP-0394.