### PR TITLE
Store string length

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ end of this list.
 Robert Nystrom <robert@stuffwithstuff.com>
 Kyle Marek-Spartz <kyle.marek.spartz@gmail.com>
 Paul Woolcock <paul@woolcock.us>
+Evan Shaw <edsrzf@gmail.com>

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -947,7 +947,7 @@ DEF_NATIVE(string_eqeq)
   ObjString* a = AS_STRING(args[0]);
   ObjString* b = AS_STRING(args[1]);
   RETURN_BOOL(a->length == b->length &&
-    memcmp(a->value, b->value, a->length) == 0);
+      memcmp(a->value, b->value, a->length) == 0);
 }
 
 DEF_NATIVE(string_bangeq)
@@ -956,7 +956,7 @@ DEF_NATIVE(string_bangeq)
   ObjString* a = AS_STRING(args[0]);
   ObjString* b = AS_STRING(args[1]);
   RETURN_BOOL(a->length != b->length ||
-    memcmp(a->value, b->value, a->length) != 0);
+      memcmp(a->value, b->value, a->length) != 0);
 }
 
 DEF_NATIVE(string_subscript)

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -915,18 +915,18 @@ DEF_NATIVE(string_contains)
 {
   if (!validateString(vm, args, 1, "Argument")) return PRIM_ERROR;
 
-  const char* string = AS_CSTRING(args[0]);
-  const char* search = AS_CSTRING(args[1]);
+  ObjString* string = AS_STRING(args[0]);
+  ObjString* search = AS_STRING(args[1]);
 
   // Corner case, the empty string contains the empty string.
-  if (strlen(string) == 0 && strlen(search) == 0) RETURN_TRUE;
+  if (string->length == 0 && search->length == 0) RETURN_TRUE;
 
-  RETURN_BOOL(strstr(string, search) != NULL);
+  RETURN_BOOL(strstr(string->value, search->value) != NULL);
 }
 
 DEF_NATIVE(string_count)
 {
-  double count = strlen(AS_CSTRING(args[0]));
+  double count = AS_STRING(args[0])->length;
   RETURN_NUM(count);
 }
 
@@ -944,26 +944,26 @@ DEF_NATIVE(string_plus)
 DEF_NATIVE(string_eqeq)
 {
   if (!IS_STRING(args[1])) RETURN_FALSE;
-  const char* a = AS_CSTRING(args[0]);
-  const char* b = AS_CSTRING(args[1]);
-  RETURN_BOOL(strcmp(a, b) == 0);
+  ObjString* a = AS_STRING(args[0]);
+  ObjString* b = AS_STRING(args[1]);
+  RETURN_BOOL(a->length == b->length &&
+    memcmp(a->value, b->value, a->length) == 0);
 }
 
 DEF_NATIVE(string_bangeq)
 {
   if (!IS_STRING(args[1])) RETURN_TRUE;
-  const char* a = AS_CSTRING(args[0]);
-  const char* b = AS_CSTRING(args[1]);
-  RETURN_BOOL(strcmp(a, b) != 0);
+  ObjString* a = AS_STRING(args[0]);
+  ObjString* b = AS_STRING(args[1]);
+  RETURN_BOOL(a->length != b->length ||
+    memcmp(a->value, b->value, a->length) != 0);
 }
 
 DEF_NATIVE(string_subscript)
 {
   ObjString* string = AS_STRING(args[0]);
-  // TODO: Strings should cache their length.
-  int length = (int)strlen(string->value);
 
-  int index = validateIndex(vm, args, length, 1, "Subscript");
+  int index = validateIndex(vm, args, string->length, 1, "Subscript");
   if (index == -1) return PRIM_ERROR;
 
   // The result is a one-character string.

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -341,6 +341,7 @@ Value wrenNewUninitializedString(WrenVM* vm, size_t length)
 {
   ObjString* string = allocate(vm, sizeof(ObjString) + length + 1);
   initObj(vm, &string->obj, OBJ_STRING, vm->stringClass);
+  string->length = length;
 
   return OBJ_VAL(string);
 }

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -388,9 +388,7 @@ static void markString(WrenVM* vm, ObjString* string)
   if (setMarkedFlag(&string->obj)) return;
 
   // Keep track of how much memory is still in use.
-  vm->bytesAllocated += sizeof(ObjString);
-  // TODO: O(n) calculation here is lame!
-  vm->bytesAllocated += strlen(string->value);
+  vm->bytesAllocated += sizeof(ObjString) + string->length + 1;
 }
 
 static void markClass(WrenVM* vm, ObjClass* classObj)

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -108,7 +108,8 @@ DECLARE_BUFFER(Value, Value);
 typedef struct
 {
   Obj obj;
-  size_t length; // not including null terminator
+  // Does not include the null terminator.
+  size_t length;
   char value[];
 } ObjString;
 

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -108,6 +108,7 @@ DECLARE_BUFFER(Value, Value);
 typedef struct
 {
   Obj obj;
+  size_t length; // not including null terminator
   char value[];
 } ObjString;
 


### PR DESCRIPTION
Strings now store their length. They're still null-terminated so that they're easy to use in C.

Most code has been updated to take advantage of this, including a couple removed TODOs. The notable exception is `wrenStringConcat`, which is a little more involved.

I also sneakily added myself to AUTHORS, which I hope is okay to do within the same pull request.

Benchmarks are unchanged (which is expected, since there's almost no string stuff):

    $ ./run_bench -l wren
    binary_trees - wren            ..........  3020  0.33s  100.23% relative to baseline
    delta_blue - wren              ..........  5782  0.17s   98.79% relative to baseline
    fib - wren                     ..........  1835  0.55s  100.07% relative to baseline
    for - wren                     ..........  5287  0.19s  100.39% relative to baseline
    method_call - wren             ..........  3483  0.29s   99.74% relative to baseline