### PR TITLE
Segfault when calling super at top-level with no arguments.

### DIFF
--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -1835,28 +1835,36 @@ static void super_(Compiler* compiler, bool allowAssignment)
   else if (enclosingClass->isStaticMethod)
   {
     error(compiler, "Cannot use 'super' in a static method.");
-  } else {
-    loadThis(compiler);
+  }
 
-    // TODO: Super operator calls.
+  loadThis(compiler);
 
-    // See if it's a named super call, or an unnamed one.
-    if (match(compiler, TOKEN_DOT))
-    {
-      // Compile the superclass call.
-      consume(compiler, TOKEN_NAME, "Expect method name after 'super.'.");
-      namedCall(compiler, allowAssignment, CODE_SUPER_0);
-    }
-    else
-    {
-      // No explicit name, so use the name of the enclosing method.
-      char name[MAX_METHOD_SIGNATURE];
-      int length = enclosingClass->methodLength;
+  // TODO: Super operator calls.
+
+  // See if it's a named super call, or an unnamed one.
+  if (match(compiler, TOKEN_DOT))
+  {
+    // Compile the superclass call.
+    consume(compiler, TOKEN_NAME, "Expect method name after 'super.'.");
+    namedCall(compiler, allowAssignment, CODE_SUPER_0);
+  }
+  else
+  {
+    // No explicit name, so use the name of the enclosing method.
+    char name[MAX_METHOD_SIGNATURE];
+    int length;
+    if (enclosingClass != NULL) {
+      length = enclosingClass->methodLength;
       strncpy(name, enclosingClass->methodName, length);
-
-      // Call the superclass method with the same name.
-      methodCall(compiler, CODE_SUPER_0, name, length);
+    } else {
+      // The compiler errored since super is called outside a method.
+      // We want to continue, but we cannot generate valid bytecode.
+      length = 0;
+      strncpy(name, "", length);
     }
+
+    // Call the superclass method with the same name.
+    methodCall(compiler, CODE_SUPER_0, name, length);
   }
 }
 

--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -1835,28 +1835,28 @@ static void super_(Compiler* compiler, bool allowAssignment)
   else if (enclosingClass->isStaticMethod)
   {
     error(compiler, "Cannot use 'super' in a static method.");
-  }
+  } else {
+    loadThis(compiler);
 
-  loadThis(compiler);
+    // TODO: Super operator calls.
 
-  // TODO: Super operator calls.
+    // See if it's a named super call, or an unnamed one.
+    if (match(compiler, TOKEN_DOT))
+    {
+      // Compile the superclass call.
+      consume(compiler, TOKEN_NAME, "Expect method name after 'super.'.");
+      namedCall(compiler, allowAssignment, CODE_SUPER_0);
+    }
+    else
+    {
+      // No explicit name, so use the name of the enclosing method.
+      char name[MAX_METHOD_SIGNATURE];
+      int length = enclosingClass->methodLength;
+      strncpy(name, enclosingClass->methodName, length);
 
-  // See if it's a named super call, or an unnamed one.
-  if (match(compiler, TOKEN_DOT))
-  {
-    // Compile the superclass call.
-    consume(compiler, TOKEN_NAME, "Expect method name after 'super.'.");
-    namedCall(compiler, allowAssignment, CODE_SUPER_0);
-  }
-  else
-  {
-    // No explicit name, so use the name of the enclosing method.
-    char name[MAX_METHOD_SIGNATURE];
-    int length = enclosingClass->methodLength;
-    strncpy(name, enclosingClass->methodName, length);
-
-    // Call the superclass method with the same name.
-    methodCall(compiler, CODE_SUPER_0, name, length);
+      // Call the superclass method with the same name.
+      methodCall(compiler, CODE_SUPER_0, name, length);
+    }
   }
 }
 

--- a/test/super/super_at_top_level.wren
+++ b/test/super/super_at_top_level.wren
@@ -1,1 +1,2 @@
 super.foo // expect error
+super // expect error

--- a/test/super/super_at_top_level.wren
+++ b/test/super/super_at_top_level.wren
@@ -1,2 +1,4 @@
 super.foo // expect error
 super // expect error
+super.foo("bar") // expect error
+super("foo") // expect error


### PR DESCRIPTION
If enclosingClass is null, we can't proceed with compilation since we don't have its name.