### PR TITLE
Add waffle.io badge / link to kanban board.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ If you like the sound of this, [give it a try][try]! Even better, you can
 
 [![Build Status](https://travis-ci.org/munificent/wren.svg)](https://travis-ci.org/munificent/wren)
 
+[![Stories in Ready](https://badge.waffle.io/munificent/wren.svg)](http://waffle.io/munificent/wren)
+
+
 [syntax]: http://munificent.github.io/wren/syntax.html
 [src]: https://github.com/munificent/wren/tree/master/src
 [nan]: https://github.com/munificent/wren/blob/46c1ba92492e9257aba6418403161072d640cb29/src/wren_value.h#L378-L433


### PR DESCRIPTION
I'm not sure what your thoughts are on Kanban, but it is another GitHub integration.