### PR TITLE
Allow better debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ AR = ar rcu
 # Compiler flags.
 CFLAGS = -std=c99 -Wall -Werror
 # TODO: Add -Wextra.
-DEBUG_CFLAGS = -O0 -DDEBUG
+DEBUG_CFLAGS = -O0 -DDEBUG -g
 RELEASE_CFLAGS = -Os
 
 # Files.


### PR DESCRIPTION
This will ensure that we have better output when running `wren` under
{g,ll}db.