### PR TITLE
POC for `methods` call on all objects.

### DIFF
--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -818,6 +818,50 @@ DEF_NATIVE(object_bangeq)
   RETURN_BOOL(!wrenValuesEqual(args[0], args[1]));
 }
 
+DEF_NATIVE(object_methods)
+{
+
+  ObjClass* classObj;
+
+  // For booleans, null and numbers we may be dealing with the primitive values
+  // instead of an object instance so we have to get the class that implements
+  // them directly.
+  if (IS_BOOL(args[0])) classObj = vm->boolClass;
+  else if (IS_NULL(args[0])) classObj = vm->nullClass;
+  else if (IS_NUM(args[0])) classObj = vm->numClass;
+  else
+  {
+    // For every other class simply pull the class object off of the instance.
+    ObjInstance* objInstance = AS_INSTANCE(args[0]);
+    classObj = objInstance->obj.classObj;
+  }
+
+  ObjList* methodList = wrenNewList(vm, 0);
+
+  for (int i = 0; i < classObj->methods.count; i++)
+  {
+    Method* method = &classObj->methods.data[i];
+    switch (method->type)
+    {
+      case METHOD_BLOCK:
+      case METHOD_PRIMITIVE:
+      case METHOD_FOREIGN:
+      {
+        // Retrieve the method name from the global symbol table.
+        char* symbolName = vm->methodNames.data[i];
+
+        Value methodName = wrenNewString(vm, symbolName, strlen(symbolName));
+        wrenListAdd(vm, methodList, methodName);
+        break;
+      }
+      case METHOD_NONE:
+        break;
+    }
+  }
+
+  RETURN_OBJ(methodList);
+}
+
 DEF_NATIVE(object_new)
 {
   // This is the default argument-less constructor that all objects inherit.
@@ -1072,6 +1116,7 @@ void wrenInitializeCore(WrenVM* vm)
   vm->objectClass = defineSingleClass(vm, "Object");
   NATIVE(vm->objectClass, "== ", object_eqeq);
   NATIVE(vm->objectClass, "!= ", object_bangeq);
+  NATIVE(vm->objectClass, "methods", object_methods);
   NATIVE(vm->objectClass, "new", object_new);
   NATIVE(vm->objectClass, "toString", object_toString);
   NATIVE(vm->objectClass, "type", object_type);


### PR DESCRIPTION
This is my first stab at a `methods` function on all objects which returns a list of methods that you can call on that object. It has one big blocker in that it returns operators and behind the scenes methods:

```dart
  class Foo {}
  var foo = new Foo
  IO.print(foo.methods) 
  // current output: [== , != , methods, new, toString, type,  instantiate]
  // correct output: [methods, toString, type]
```

Now it appears those symbols are always mapped to the same spot in the symbol table so we could just filter out symbols by name or their index in the symbol table. I was hoping there would be some more clever/correct(?) ideas out there.