### PR TITLE
Fix precedence of % operator

### DIFF
--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -2183,7 +2183,7 @@ GrammarRule rules[] =
   /* TOKEN_COMMA         */ UNUSED,
   /* TOKEN_STAR          */ INFIX_OPERATOR(PREC_FACTOR, "* "),
   /* TOKEN_SLASH         */ INFIX_OPERATOR(PREC_FACTOR, "/ "),
-  /* TOKEN_PERCENT       */ INFIX_OPERATOR(PREC_TERM, "% "),
+  /* TOKEN_PERCENT       */ INFIX_OPERATOR(PREC_FACTOR, "% "),
   /* TOKEN_PLUS          */ INFIX_OPERATOR(PREC_TERM, "+ "),
   /* TOKEN_MINUS         */ OPERATOR("- "),
   /* TOKEN_PIPE          */ INFIX_OPERATOR(PREC_BITWISE, "| "),

--- a/test/number/mod.wren
+++ b/test/number/mod.wren
@@ -10,5 +10,8 @@ IO.print(-4.2 % -3.1) // expect: -1.1
 // Left associative.
 IO.print(13 % 7 % 4) // expect: 2
 
+// Precedence.
+IO.print(13 + 1 % 7) // expect: 14
+
 // TODO: Unsupported RHS types.
 // TODO: Error on mod by zero.


### PR DESCRIPTION
It previously had the same precedence as + and -.

I assume this was a bug, but feel free to close this pull request if it's not.