### PR TITLE
Signed unsigned warnings

### DIFF
--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -1209,8 +1209,8 @@ DEF_NATIVE(string_iterate)
 
   if (!validateInt(vm, args, 1, "Iterator")) return PRIM_ERROR;
 
-  int index = (int)AS_NUM(args[1]);
-  if (index < 0) RETURN_FALSE;
+  size_t index = (uint32_t)AS_NUM(args[1]);
+  if (index >= string->length) RETURN_FALSE;
 
   // Advance to the beginning of the next UTF-8 sequence.
   do

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -659,10 +659,10 @@ DEF_NATIVE(list_iterate)
 
   if (!validateInt(vm, args, 1, "Iterator")) return PRIM_ERROR;
 
-  int index = (int)AS_NUM(args[1]);
+  size_t index = (size_t)AS_NUM(args[1]);
 
   // Stop if we're out of bounds.
-  if (index < 0 || index >= list->count - 1) RETURN_FALSE;
+  if (index >= list->count - 1) RETURN_FALSE;
 
   // Otherwise, move to the next index.
   RETURN_NUM(index + 1);

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -776,13 +776,13 @@ DEF_NATIVE(map_iterate)
   if (map->count == 0) RETURN_FALSE;
 
   // If we're starting the iteration, return the first entry.
-  int index = -1;
+  uint32_t index = UINT32_MAX;
   if (!IS_NULL(args[1]))
   {
     if (!validateInt(vm, args, 1, "Iterator")) return PRIM_ERROR;
-    index = (int)AS_NUM(args[1]);
+    index = (uint32_t)AS_NUM(args[1]);
 
-    if (index < 0 || index >= map->capacity) RETURN_FALSE;
+    if (index >= map->capacity) RETURN_FALSE;
   }
 
   // Find the next used entry, if any.

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -776,7 +776,7 @@ DEF_NATIVE(map_iterate)
   if (map->count == 0) RETURN_FALSE;
 
   // If we're starting the iteration, return the first entry.
-  uint32_t index = UINT32_MAX;
+  size_t index = SIZE_MAX;
   if (!IS_NULL(args[1]))
   {
     if (!validateInt(vm, args, 1, "Iterator")) return PRIM_ERROR;

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -778,7 +778,7 @@ static void markMap(WrenVM* vm, ObjMap* map)
   if (setMarkedFlag(&map->obj)) return;
 
   // Mark the entries.
-  for (int i = 0; i < map->capacity; i++)
+  for (uint32_t i = 0; i < map->capacity; i++)
   {
     MapEntry* entry = &map->entries[i];
     if (IS_UNDEFINED(entry->key)) continue;

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -778,7 +778,7 @@ static void markMap(WrenVM* vm, ObjMap* map)
   if (setMarkedFlag(&map->obj)) return;
 
   // Mark the entries.
-  for (uint32_t i = 0; i < map->capacity; i++)
+  for (size_t i = 0; i < map->capacity; i++)
   {
     MapEntry* entry = &map->entries[i];
     if (IS_UNDEFINED(entry->key)) continue;

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -234,7 +234,7 @@ Value wrenNewInstance(WrenVM* vm, ObjClass* classObj)
   return OBJ_VAL(instance);
 }
 
-ObjList* wrenNewList(WrenVM* vm, int numElements)
+ObjList* wrenNewList(WrenVM* vm, size_t numElements)
 {
   // Allocate this before the list object in case it triggers a GC which would
   // free the list.
@@ -278,7 +278,7 @@ void wrenListAdd(WrenVM* vm, ObjList* list, Value value)
   list->elements[list->count++] = value;
 }
 
-void wrenListInsert(WrenVM* vm, ObjList* list, Value value, int index)
+void wrenListInsert(WrenVM* vm, ObjList* list, Value value, size_t index)
 {
   if (IS_OBJ(value)) wrenPushRoot(vm, AS_OBJ(value));
 
@@ -287,7 +287,7 @@ void wrenListInsert(WrenVM* vm, ObjList* list, Value value, int index)
   if (IS_OBJ(value)) wrenPopRoot(vm);
 
   // Shift items down.
-  for (int i = list->count; i > index; i--)
+  for (size_t i = list->count; i > index; i--)
   {
     list->elements[i] = list->elements[i - 1];
   }
@@ -296,14 +296,14 @@ void wrenListInsert(WrenVM* vm, ObjList* list, Value value, int index)
   list->count++;
 }
 
-Value wrenListRemoveAt(WrenVM* vm, ObjList* list, int index)
+Value wrenListRemoveAt(WrenVM* vm, ObjList* list, size_t index)
 {
   Value removed = list->elements[index];
 
   if (IS_OBJ(removed)) wrenPushRoot(vm, AS_OBJ(removed));
 
   // Shift items up.
-  for (int i = index; i < list->count - 1; i++)
+  for (size_t i = index; i < list->count - 1; i++)
   {
     list->elements[i] = list->elements[i + 1];
   }
@@ -763,7 +763,7 @@ static void markList(WrenVM* vm, ObjList* list)
 
   // Mark the elements.
   Value* elements = list->elements;
-  for (int i = 0; i < list->count; i++)
+  for (size_t i = 0; i < list->count; i++)
   {
     wrenMarkValue(vm, elements[i]);
   }

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -636,9 +636,8 @@ ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right)
   return string;
 }
 
-Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, int index)
+Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, size_t index)
 {
-  ASSERT(index >= 0, "Index out of bounds.");
   ASSERT(index < string->length, "Index out of bounds.");
 
   char first = string->value[index];

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -369,8 +369,8 @@ static uint32_t hashObject(Obj* object)
       // towards the prefix or suffix of the string. So sample up to eight
       // characters spread throughout the string.
       // TODO: Tune this.
-      uint32_t step = 1 + 7 / string->length;
-      for (uint32_t i = 0; i < string->length; i += step)
+      size_t step = 1 + 7 / string->length;
+      for (size_t i = 0; i < string->length; i += step)
       {
         hash ^= string->value[i];
         hash *= 16777619;

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -116,7 +116,7 @@ typedef struct
 {
   Obj obj;
   // Does not include the null terminator.
-  int length;
+  size_t length;
   char value[FLEXIBLE_ARRAY];
 } ObjString;
 

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -335,13 +335,11 @@ typedef struct
 {
   Obj obj;
 
-  // TODO: Make these uint32_t to match ObjMap, or vice versa.
-  
   // The number of elements allocated.
-  int capacity;
+  size_t capacity;
 
   // The number of items in the list.
-  int count;
+  size_t count;
 
   // Pointer to a contiguous array of [capacity] elements.
   Value* elements;
@@ -624,16 +622,16 @@ Value wrenNewInstance(WrenVM* vm, ObjClass* classObj);
 
 // Creates a new list with [numElements] elements (which are left
 // uninitialized.)
-ObjList* wrenNewList(WrenVM* vm, int numElements);
+ObjList* wrenNewList(WrenVM* vm, size_t numElements);
 
 // Adds [value] to [list], reallocating and growing its storage if needed.
 void wrenListAdd(WrenVM* vm, ObjList* list, Value value);
 
 // Inserts [value] in [list] at [index], shifting down the other elements.
-void wrenListInsert(WrenVM* vm, ObjList* list, Value value, int index);
+void wrenListInsert(WrenVM* vm, ObjList* list, Value value, size_t index);
 
 // Removes and returns the item at [index] from [list].
-Value wrenListRemoveAt(WrenVM* vm, ObjList* list, int index);
+Value wrenListRemoveAt(WrenVM* vm, ObjList* list, size_t index);
 
 // Creates a new empty map.
 ObjMap* wrenNewMap(WrenVM* vm);

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -362,10 +362,10 @@ typedef struct
   Obj obj;
 
   // The number of entries allocated.
-  uint32_t capacity;
+  size_t capacity;
 
   // The number of entries in the map.
-  uint32_t count;
+  size_t count;
 
   // Pointer to a contiguous array of [capacity] entries.
   MapEntry* entries;

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -669,7 +669,7 @@ ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right);
 // Creates a new string containing the code point in [string] starting at byte
 // [index]. If [index] points into the middle of a UTF-8 sequence, returns an
 // empty string.
-Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, int index);
+Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, size_t index);
 
 // Creates a new open upvalue pointing to [value] on the stack.
 Upvalue* wrenNewUpvalue(WrenVM* vm, Value* value);


### PR DESCRIPTION
I began by snooking some minor signed/unsigned warnings in the max indexing variable use..

.. and finished in changing the maps/lists/strings size-tracking variable type.

It should be `size_t`, as standard "suggests".