### PR TITLE
Using array of pointers to store the predefined types.

### DIFF
--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -1392,6 +1392,7 @@ void wrenInitializeCore(WrenVM* vm)
   vm->types[TYPE_FN] = defineClass(vm, "Fn");
   NATIVE(vm->types[TYPE_FN]->obj.classObj, " instantiate", fn_instantiate);
   NATIVE(vm->types[TYPE_FN]->obj.classObj, "new ", fn_new);
+  NATIVE(vm->types[TYPE_FN], "arity", fn_arity);
   NATIVE(vm->types[TYPE_FN], "call", fn_call0);
   NATIVE(vm->types[TYPE_FN], "call ", fn_call1);
   NATIVE(vm->types[TYPE_FN], "call  ", fn_call2);

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -1416,9 +1416,6 @@ void wrenInitializeCore(WrenVM* vm)
   NATIVE(vm->types[TYPE_NULL], "toString", null_toString);
 
   vm->types[TYPE_NUM] = defineClass(vm, "Num");
-  NATIVE(vm->types[TYPE_NUM]->obj.classObj, "srand", num_srand0);
-  NATIVE(vm->types[TYPE_NUM]->obj.classObj, "srand ", num_srand1);
-  NATIVE(vm->types[TYPE_NUM]->obj.classObj, "rand", num_rand);
   NATIVE(vm->types[TYPE_NUM], "-", num_negate);
   NATIVE(vm->types[TYPE_NUM], "- ", num_minus);
   NATIVE(vm->types[TYPE_NUM], "+ ", num_plus);
@@ -1437,16 +1434,11 @@ void wrenInitializeCore(WrenVM* vm)
   NATIVE(vm->types[TYPE_NUM], "abs", num_abs);
   NATIVE(vm->types[TYPE_NUM], "ceil", num_ceil);
   NATIVE(vm->types[TYPE_NUM], "cos", num_cos);
-  NATIVE(vm->types[TYPE_NUM], "def", num_deg);
-  NATIVE(vm->types[TYPE_NUM], "frac", num_frac);
   NATIVE(vm->types[TYPE_NUM], "floor", num_floor);
   NATIVE(vm->types[TYPE_NUM], "isNan", num_isNan);
-  NATIVE(vm->types[TYPE_NUM], "rad", num_rad);
-  NATIVE(vm->types[TYPE_NUM], "round", num_round);
   NATIVE(vm->types[TYPE_NUM], "sin", num_sin);
   NATIVE(vm->types[TYPE_NUM], "sqrt", num_sqrt);
   NATIVE(vm->types[TYPE_NUM], "toString", num_toString)
-  NATIVE(vm->types[TYPE_NUM], "truncate", num_truncate);
   // These are defined just so that 0 and -0 are equal, which is specified by
   // IEEE 754 even though they have different bit representations.
   NATIVE(vm->types[TYPE_NUM], "== ", num_eqeq);

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -87,7 +87,7 @@ ObjClass* wrenNewClass(WrenVM* vm, ObjClass* superclass, int numFields,
   wrenPushRoot(vm, (Obj*)metaclassName);
 
   ObjClass* metaclass = wrenNewSingleClass(vm, 0, metaclassName);
-  metaclass->obj.classObj = vm->classClass;
+  metaclass->obj.classObj = vm->types[TYPE_CLASS];
 
   wrenPopRoot(vm);
 
@@ -96,7 +96,7 @@ ObjClass* wrenNewClass(WrenVM* vm, ObjClass* superclass, int numFields,
 
   // Metaclasses always inherit Class and do not parallel the non-metaclass
   // hierarchy.
-  wrenBindSuperclass(vm, metaclass, vm->classClass);
+  wrenBindSuperclass(vm, metaclass, vm->types[TYPE_CLASS]);
 
   ObjClass* classObj = wrenNewSingleClass(vm, numFields, name);
 
@@ -132,7 +132,7 @@ ObjClosure* wrenNewClosure(WrenVM* vm, ObjFn* fn)
 {
   ObjClosure* closure = ALLOCATE_FLEX(vm, ObjClosure,
                                       sizeof(Upvalue*) * fn->numUpvalues);
-  initObj(vm, &closure->obj, OBJ_CLOSURE, vm->fnClass);
+  initObj(vm, &closure->obj, OBJ_CLOSURE, vm->types[TYPE_FN]);
 
   closure->fn = fn;
 
@@ -146,7 +146,7 @@ ObjClosure* wrenNewClosure(WrenVM* vm, ObjFn* fn)
 ObjFiber* wrenNewFiber(WrenVM* vm, Obj* fn)
 {
   ObjFiber* fiber = ALLOCATE(vm, ObjFiber);
-  initObj(vm, &fiber->obj, OBJ_FIBER, vm->fiberClass);
+  initObj(vm, &fiber->obj, OBJ_FIBER, vm->types[TYPE_FIBER]);
 
   // Push the stack frame for the function.
   fiber->stackTop = fiber->stack;
@@ -202,7 +202,7 @@ ObjFn* wrenNewFunction(WrenVM* vm, Value* constants, int numConstants,
   debug->sourceLines = sourceLines;
 
   ObjFn* fn = ALLOCATE(vm, ObjFn);
-  initObj(vm, &fn->obj, OBJ_FN, vm->fnClass);
+  initObj(vm, &fn->obj, OBJ_FN, vm->types[TYPE_FN]);
 
   // TODO: Should eventually copy this instead of taking ownership. When the
   // compiler grows this, its capacity will often exceed the actual used size.
@@ -245,7 +245,7 @@ ObjList* wrenNewList(WrenVM* vm, int numElements)
   }
 
   ObjList* list = ALLOCATE(vm, ObjList);
-  initObj(vm, &list->obj, OBJ_LIST, vm->listClass);
+  initObj(vm, &list->obj, OBJ_LIST, vm->types[TYPE_LIST]);
   list->capacity = numElements;
   list->count = numElements;
   list->elements = elements;
@@ -326,7 +326,7 @@ Value wrenListRemoveAt(WrenVM* vm, ObjList* list, int index)
 ObjMap* wrenNewMap(WrenVM* vm)
 {
   ObjMap* map = ALLOCATE(vm, ObjMap);
-  initObj(vm, &map->obj, OBJ_MAP, vm->mapClass);
+  initObj(vm, &map->obj, OBJ_MAP, vm->types[TYPE_MAP]);
   map->capacity = 0;
   map->count = 0;
   map->entries = NULL;
@@ -588,7 +588,7 @@ Value wrenMapRemoveKey(WrenVM* vm, ObjMap* map, Value key)
 Value wrenNewRange(WrenVM* vm, double from, double to, bool isInclusive)
 {
   ObjRange* range = ALLOCATE(vm, ObjRange);
-  initObj(vm, &range->obj, OBJ_RANGE, vm->rangeClass);
+  initObj(vm, &range->obj, OBJ_RANGE, vm->types[TYPE_RANGE]);
   range->from = from;
   range->to = to;
   range->isInclusive = isInclusive;
@@ -616,7 +616,7 @@ Value wrenNewString(WrenVM* vm, const char* text, size_t length)
 Value wrenNewUninitializedString(WrenVM* vm, size_t length)
 {
   ObjString* string = ALLOCATE_FLEX(vm, ObjString, length + 1);
-  initObj(vm, &string->obj, OBJ_STRING, vm->stringClass);
+  initObj(vm, &string->obj, OBJ_STRING, vm->types[TYPE_STRING]);
   string->length = (int)length;
 
   return OBJ_VAL(string);

--- a/src/wren_vm.c
+++ b/src/wren_vm.c
@@ -967,7 +967,7 @@ static bool runInterpreter(WrenVM* vm)
       if (IS_NULL(PEEK()))
       {
         // Implicit Object superclass.
-        superclass = vm->objectClass;
+        superclass = vm->types[TYPE_OBJECT];
       }
       else
       {
@@ -1131,7 +1131,7 @@ static void defineMethod(WrenVM* vm, const char* className,
     wrenPushRoot(vm, (Obj*)nameString);
 
     // TODO: Allow passing in name for superclass?
-    classObj = wrenNewClass(vm, vm->objectClass, 0, nameString);
+    classObj = wrenNewClass(vm, vm->types[TYPE_OBJECT], 0, nameString);
     wrenDefineGlobal(vm, className, length, OBJ_VAL(classObj));
 
     wrenPopRoot(vm);

--- a/src/wren_vm.h
+++ b/src/wren_vm.h
@@ -177,21 +177,26 @@ typedef enum
   CODE_END
 } Code;
 
+typedef enum {
+  TYPE_BOOL,
+  TYPE_CLASS,
+  TYPE_FIBER,
+  TYPE_FN,
+  TYPE_LIST,
+  TYPE_MAP,
+  TYPE_NULL,
+  TYPE_NUM,
+  TYPE_OBJECT,
+  TYPE_RANGE,
+  TYPE_STRING,
+  Type_CountOf,
+} Type;
+
 // TODO: Move into wren_vm.c?
 struct WrenVM
 {
-  // TODO: Use an array for some of these.
-  ObjClass* boolClass;
-  ObjClass* classClass;
-  ObjClass* fiberClass;
-  ObjClass* fnClass;
-  ObjClass* listClass;
-  ObjClass* mapClass;
-  ObjClass* nullClass;
-  ObjClass* numClass;
-  ObjClass* objectClass;
-  ObjClass* rangeClass;
-  ObjClass* stringClass;
+  // The array of predefined types.
+  ObjClass* types[Type_CountOf];
 
   // The currently defined global variables.
   ValueBuffer globals;
@@ -308,24 +313,24 @@ void wrenPopRoot(WrenVM* vm);
 static inline ObjClass* wrenGetClassInline(WrenVM* vm, Value value)
 {
 #if WREN_NAN_TAGGING
-  if (IS_NUM(value)) return vm->numClass;
+  if (IS_NUM(value)) return vm->types[TYPE_NUM];
   if (IS_OBJ(value)) return AS_OBJ(value)->classObj;
 
   switch (GET_TAG(value))
   {
-    case TAG_FALSE: return vm->boolClass; break;
-    case TAG_NAN: return vm->numClass; break;
-    case TAG_NULL: return vm->nullClass; break;
-    case TAG_TRUE: return vm->boolClass; break;
+    case TAG_FALSE: return vm->types[TYPE_BOOL]; break;
+    case TAG_NAN: return vm->types[TYPE_NUM]; break;
+    case TAG_NULL: return vm->types[TYPE_NULL]; break;
+    case TAG_TRUE: return vm->types[TYPE_BOOL]; break;
     case TAG_UNDEFINED: UNREACHABLE();
   }
 #else
   switch (value.type)
   {
-    case VAL_FALSE: return vm->boolClass;
-    case VAL_NULL: return vm->nullClass;
-    case VAL_NUM: return vm->numClass;
-    case VAL_TRUE: return vm->boolClass;
+    case VAL_FALSE: return vm->types[TYPE_BOOL];
+    case VAL_NULL: return vm->types[TYPE_NULL];
+	case VAL_NUM: return vm->types[TYPE_NUM];
+    case VAL_TRUE: return vm->types[TYPE_BOOL];
     case VAL_OBJ: return AS_OBJ(value)->classObj;
     case VAL_UNDEFINED: UNREACHABLE();
   }


### PR DESCRIPTION
Noticed the "TODO" in the source and switched to use an array-of-pointers to store the predefined types variables.

I'm not completely sure it was worth the effort. Surely a "elegant" approach, but may affect the performances due to the needed array referencing math (although the optimizer should dampen this). Moreover, it's not so easy on the eyes when reading.

What's your opinion?