### PR TITLE
Bitfields usage

### DIFF
--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -40,7 +40,7 @@ DEFINE_BUFFER(Method, Method);
 static void initObj(WrenVM* vm, Obj* obj, ObjType type, ObjClass* classObj)
 {
   obj->type = type;
-  obj->flags = 0;
+  obj->marked = false;
   obj->classObj = classObj;
   obj->next = vm->first;
   vm->first = obj;
@@ -678,8 +678,8 @@ Upvalue* wrenNewUpvalue(WrenVM* vm, Value* value)
 // crash on an object cycle.
 static bool setMarkedFlag(Obj* obj)
 {
-  if (obj->flags & FLAG_MARKED) return true;
-  obj->flags |= FLAG_MARKED;
+  if (obj->marked) return true;
+  obj->marked = true;
   return false;
 }
 

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -62,19 +62,13 @@ typedef enum {
   OBJ_UPVALUE
 } ObjType;
 
-typedef enum
-{
-  // The object has been marked during the mark phase of GC.
-  FLAG_MARKED = 0x01,
-} ObjFlags;
-
 typedef struct sObjClass ObjClass;
 
 // Base struct for all heap-allocated objects.
 typedef struct sObj
 {
   ObjType type;
-  ObjFlags flags;
+  bool marked;
 
   // The object's class.
   ObjClass* classObj;

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -73,10 +73,8 @@ typedef struct sObjClass ObjClass;
 // Base struct for all heap-allocated objects.
 typedef struct sObj
 {
-  unsigned int type  : 4; // ObjType.
-  // TODO: We could store this bit off to the side, or in the low bit of
-  // classObj to shrink objects a bit. Worth doing?
-  unsigned int flags : 1; // ObjFlags.
+  ObjType type;
+  ObjFlags flags;
 
   // The object's class.
   ObjClass* classObj;

--- a/src/wren_vm.c
+++ b/src/wren_vm.c
@@ -147,7 +147,7 @@ static void collectGarbage(WrenVM* vm)
   Obj** obj = &vm->first;
   while (*obj != NULL)
   {
-    if (!((*obj)->flags & FLAG_MARKED))
+    if (!((*obj)->marked))
     {
       // This object wasn't reached, so remove it from the list and free it.
       Obj* unreached = *obj;
@@ -158,7 +158,7 @@ static void collectGarbage(WrenVM* vm)
     {
       // This object was reached, so unmark it (for the next GC) and move on to
       // the next.
-      (*obj)->flags &= ~FLAG_MARKED;
+      (*obj)->marked = false;
       obj = &(*obj)->next;
     }
   }


### PR DESCRIPTION
Just noticed that the 'Obj' structure is using bitfields to track the object type and GC flag.

In my opinion this should be avoided. Bitfields are useful when handling packed structures, but that's not the case.

Having not specified a strict struct-field alignment, we would end allocating `sizeof(int)` bytes for each field.

Also, the required math to access the bitfields (mask and shift) can affect performances.