### PR TITLE
String lengths as 'int'

### DIFF
--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -508,8 +508,8 @@ static void skipBlockComment(Parser* parser)
 // Returns true if the current token's text matches [keyword].
 static bool isKeyword(Parser* parser, const char* keyword)
 {
-  int length = parser->currentChar - parser->tokenStart;
-  int keywordLength = (int)strlen(keyword);
+  uint32_t length = parser->currentChar - parser->tokenStart;
+  uint32_t keywordLength = (uint32_t)strlen(keyword);
   return length == keywordLength &&
       strncmp(parser->tokenStart, keyword, length) == 0;
 }
@@ -1519,16 +1519,16 @@ static int parameterList(Compiler* compiler, char* name, int* length,
 
 // Gets the symbol for a method [name]. If [length] is 0, it will be calculated
 // from a null-terminated [name].
-static int methodSymbol(Compiler* compiler, const char* name, int length)
+static int methodSymbol(Compiler* compiler, const char* name, uint32_t length)
 {
-  if (length == 0) length = (int)strlen(name);
+  if (length == 0) length = (uint32_t)strlen(name);
   return wrenSymbolTableEnsure(compiler->parser->vm,
       &compiler->parser->vm->methodNames, name, length);
 }
 
 // Compiles an (optional) argument list and then calls it.
 static void methodCall(Compiler* compiler, Code instruction,
-                       char name[MAX_METHOD_SIGNATURE], int length)
+                       char name[MAX_METHOD_SIGNATURE], uint32_t length)
 {
   // Parse the argument list, if any.
   int numArgs = 0;
@@ -2917,7 +2917,7 @@ void definition(Compiler* compiler)
 ObjFn* wrenCompile(WrenVM* vm, const char* sourcePath, const char* source)
 {
   ObjString* sourcePathObj = AS_STRING(wrenNewString(vm, sourcePath,
-                                                     (int)strlen(sourcePath)));
+                                                     (uint32_t)strlen(sourcePath)));
   wrenPushRoot(vm, (Obj*)sourcePathObj);
 
   Parser parser;

--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -509,7 +509,7 @@ static void skipBlockComment(Parser* parser)
 static bool isKeyword(Parser* parser, const char* keyword)
 {
   int length = parser->currentChar - parser->tokenStart;
-  int keywordLength = strlen(keyword);
+  int keywordLength = (int)strlen(keyword);
   return length == keywordLength &&
       strncmp(parser->tokenStart, keyword, length) == 0;
 }
@@ -1521,7 +1521,7 @@ static int parameterList(Compiler* compiler, char* name, int* length,
 // from a null-terminated [name].
 static int methodSymbol(Compiler* compiler, const char* name, int length)
 {
-  if (length == 0) length = strlen(name);
+  if (length == 0) length = (int)strlen(name);
   return wrenSymbolTableEnsure(compiler->parser->vm,
       &compiler->parser->vm->methodNames, name, length);
 }
@@ -2917,7 +2917,7 @@ void definition(Compiler* compiler)
 ObjFn* wrenCompile(WrenVM* vm, const char* sourcePath, const char* source)
 {
   ObjString* sourcePathObj = AS_STRING(wrenNewString(vm, sourcePath,
-                                                     strlen(sourcePath)));
+                                                     (int)strlen(sourcePath)));
   wrenPushRoot(vm, (Obj*)sourcePathObj);
 
   Parser parser;

--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -508,8 +508,8 @@ static void skipBlockComment(Parser* parser)
 // Returns true if the current token's text matches [keyword].
 static bool isKeyword(Parser* parser, const char* keyword)
 {
-  size_t length = parser->currentChar - parser->tokenStart;
-  size_t keywordLength = strlen(keyword);
+  int length = parser->currentChar - parser->tokenStart;
+  int keywordLength = strlen(keyword);
   return length == keywordLength &&
       strncmp(parser->tokenStart, keyword, length) == 0;
 }
@@ -1521,7 +1521,7 @@ static int parameterList(Compiler* compiler, char* name, int* length,
 // from a null-terminated [name].
 static int methodSymbol(Compiler* compiler, const char* name, int length)
 {
-  if (length == 0) length = (int)strlen(name);
+  if (length == 0) length = strlen(name);
   return wrenSymbolTableEnsure(compiler->parser->vm,
       &compiler->parser->vm->methodNames, name, length);
 }

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -1291,7 +1291,7 @@ DEF_NATIVE(string_subscript)
 
 static ObjClass* defineSingleClass(WrenVM* vm, const char* name)
 {
-  size_t length = strlen(name);
+  int length = strlen(name);
   ObjString* nameString = AS_STRING(wrenNewString(vm, name, length));
   wrenPushRoot(vm, (Obj*)nameString);
 
@@ -1304,7 +1304,7 @@ static ObjClass* defineSingleClass(WrenVM* vm, const char* name)
 
 static ObjClass* defineClass(WrenVM* vm, const char* name)
 {
-  size_t length = strlen(name);
+  int length = strlen(name);
   ObjString* nameString = AS_STRING(wrenNewString(vm, name, length));
   wrenPushRoot(vm, (Obj*)nameString);
 

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -11,7 +11,7 @@
 #define NATIVE(cls, name, function) \
     { \
       int symbol = wrenSymbolTableEnsure(vm, \
-          &vm->methodNames, name, (int)strlen(name)); \
+          &vm->methodNames, name, (uint32_t)strlen(name)); \
       Method method; \
       method.type = METHOD_PRIMITIVE; \
       method.fn.primitive = native_##function; \
@@ -35,7 +35,7 @@
 
 #define RETURN_ERROR(msg) \
     do { \
-      args[0] = wrenNewString(vm, msg, (int)strlen(msg)); \
+      args[0] = wrenNewString(vm, msg, (uint32_t)strlen(msg)); \
       return PRIM_ERROR; \
     } while (0);
 
@@ -1179,7 +1179,7 @@ DEF_NATIVE(string_endsWith)
   if (search->length > string->length) RETURN_FALSE;
 
   int result = memcmp(string->value + string->length - search->length,
-                       search->value, search->length);
+                      search->value, search->length);
 
   RETURN_BOOL(result == 0);
 }
@@ -1209,8 +1209,8 @@ DEF_NATIVE(string_iterate)
 
   if (!validateInt(vm, args, 1, "Iterator")) return PRIM_ERROR;
 
-  int index = (int)AS_NUM(args[1]);
-  if (index < 0) RETURN_FALSE;
+  uint32_t index = (uint32_t)AS_NUM(args[1]);
+  if (index >= string->length) RETURN_FALSE;
 
   // Advance to the beginning of the next UTF-8 sequence.
   do
@@ -1291,7 +1291,7 @@ DEF_NATIVE(string_subscript)
 
 static ObjClass* defineSingleClass(WrenVM* vm, const char* name)
 {
-  int length = (int)strlen(name);
+  uint32_t length = (uint32_t)strlen(name);
   ObjString* nameString = AS_STRING(wrenNewString(vm, name, length));
   wrenPushRoot(vm, (Obj*)nameString);
 
@@ -1304,7 +1304,7 @@ static ObjClass* defineSingleClass(WrenVM* vm, const char* name)
 
 static ObjClass* defineClass(WrenVM* vm, const char* name)
 {
-  int length = (int)strlen(name);
+  uint32_t length = (uint32_t)strlen(name);
   ObjString* nameString = AS_STRING(wrenNewString(vm, name, length));
   wrenPushRoot(vm, (Obj*)nameString);
 
@@ -1318,7 +1318,7 @@ static ObjClass* defineClass(WrenVM* vm, const char* name)
 // Returns the global variable named [name].
 static Value findGlobal(WrenVM* vm, const char* name)
 {
-  int symbol = wrenSymbolTableFind(&vm->globalNames, name, (int)strlen(name));
+  int symbol = wrenSymbolTableFind(&vm->globalNames, name, (uint32_t)strlen(name));
   return vm->globals.data[symbol];
 }
 

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -11,7 +11,7 @@
 #define NATIVE(cls, name, function) \
     { \
       int symbol = wrenSymbolTableEnsure(vm, \
-          &vm->methodNames, name, strlen(name)); \
+          &vm->methodNames, name, (int)strlen(name)); \
       Method method; \
       method.type = METHOD_PRIMITIVE; \
       method.fn.primitive = native_##function; \
@@ -35,7 +35,7 @@
 
 #define RETURN_ERROR(msg) \
     do { \
-      args[0] = wrenNewString(vm, msg, strlen(msg)); \
+      args[0] = wrenNewString(vm, msg, (int)strlen(msg)); \
       return PRIM_ERROR; \
     } while (0);
 
@@ -1291,7 +1291,7 @@ DEF_NATIVE(string_subscript)
 
 static ObjClass* defineSingleClass(WrenVM* vm, const char* name)
 {
-  int length = strlen(name);
+  int length = (int)strlen(name);
   ObjString* nameString = AS_STRING(wrenNewString(vm, name, length));
   wrenPushRoot(vm, (Obj*)nameString);
 
@@ -1304,7 +1304,7 @@ static ObjClass* defineSingleClass(WrenVM* vm, const char* name)
 
 static ObjClass* defineClass(WrenVM* vm, const char* name)
 {
-  int length = strlen(name);
+  int length = (int)strlen(name);
   ObjString* nameString = AS_STRING(wrenNewString(vm, name, length));
   wrenPushRoot(vm, (Obj*)nameString);
 
@@ -1318,7 +1318,7 @@ static ObjClass* defineClass(WrenVM* vm, const char* name)
 // Returns the global variable named [name].
 static Value findGlobal(WrenVM* vm, const char* name)
 {
-  int symbol = wrenSymbolTableFind(&vm->globalNames, name, strlen(name));
+  int symbol = wrenSymbolTableFind(&vm->globalNames, name, (int)strlen(name));
   return vm->globals.data[symbol];
 }
 

--- a/src/wren_io.c
+++ b/src/wren_io.c
@@ -124,7 +124,7 @@ static void ioRead(WrenVM* vm)
     // TODO: handle error.
   }
 
-  wrenReturnString(vm, buffer, strlen(buffer));
+  wrenReturnString(vm, buffer, (int)strlen(buffer));
 }
 
 static void ioClock(WrenVM* vm)

--- a/src/wren_io.c
+++ b/src/wren_io.c
@@ -124,7 +124,7 @@ static void ioRead(WrenVM* vm)
     // TODO: handle error.
   }
 
-  wrenReturnString(vm, buffer, (int)strlen(buffer));
+  wrenReturnString(vm, buffer, strlen(buffer));
 }
 
 static void ioClock(WrenVM* vm)

--- a/src/wren_utils.c
+++ b/src/wren_utils.c
@@ -52,7 +52,7 @@ int wrenSymbolTableFind(SymbolTable* symbols, const char* name, int length)
   for (int i = 0; i < symbols->count; i++)
   {
     // TODO: strlen() here is gross. Symbol table should store lengths.
-    if (strlen(symbols->data[i]) == length &&
+    if ((int)strlen(symbols->data[i]) == length &&
         strncmp(symbols->data[i], name, length) == 0) return i;
   }
 

--- a/src/wren_utils.c
+++ b/src/wren_utils.c
@@ -22,8 +22,8 @@ void wrenSymbolTableClear(WrenVM* vm, SymbolTable* symbols)
   wrenStringBufferClear(vm, symbols);
 }
 
-int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols, const char* name,
-                       size_t length)
+int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols,
+                       const char* name, int length)
 {
   char* heapString = (char*)wrenReallocate(vm, NULL, 0,
                                            sizeof(char) * (length + 1));
@@ -35,7 +35,7 @@ int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols, const char* name,
 }
 
 int wrenSymbolTableEnsure(WrenVM* vm, SymbolTable* symbols,
-                 const char* name, size_t length)
+                          const char* name, int length)
 {
   // See if the symbol is already defined.
   int existing = wrenSymbolTableFind(symbols, name, length);
@@ -45,7 +45,7 @@ int wrenSymbolTableEnsure(WrenVM* vm, SymbolTable* symbols,
   return wrenSymbolTableAdd(vm, symbols, name, length);
 }
 
-int wrenSymbolTableFind(SymbolTable* symbols, const char* name, size_t length)
+int wrenSymbolTableFind(SymbolTable* symbols, const char* name, int length)
 {
   // See if the symbol is already defined.
   // TODO: O(n). Do something better.

--- a/src/wren_utils.c
+++ b/src/wren_utils.c
@@ -23,7 +23,7 @@ void wrenSymbolTableClear(WrenVM* vm, SymbolTable* symbols)
 }
 
 int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols,
-                       const char* name, int length)
+                       const char* name, uint32_t length)
 {
   char* heapString = (char*)wrenReallocate(vm, NULL, 0,
                                            sizeof(char) * (length + 1));
@@ -35,7 +35,7 @@ int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols,
 }
 
 int wrenSymbolTableEnsure(WrenVM* vm, SymbolTable* symbols,
-                          const char* name, int length)
+                          const char* name, uint32_t length)
 {
   // See if the symbol is already defined.
   int existing = wrenSymbolTableFind(symbols, name, length);
@@ -45,14 +45,14 @@ int wrenSymbolTableEnsure(WrenVM* vm, SymbolTable* symbols,
   return wrenSymbolTableAdd(vm, symbols, name, length);
 }
 
-int wrenSymbolTableFind(SymbolTable* symbols, const char* name, int length)
+int wrenSymbolTableFind(SymbolTable* symbols, const char* name, uint32_t length)
 {
   // See if the symbol is already defined.
   // TODO: O(n). Do something better.
   for (int i = 0; i < symbols->count; i++)
   {
     // TODO: strlen() here is gross. Symbol table should store lengths.
-    if ((int)strlen(symbols->data[i]) == length &&
+    if ((uint32_t)strlen(symbols->data[i]) == length &&
         strncmp(symbols->data[i], name, length) == 0) return i;
   }
 

--- a/src/wren_utils.h
+++ b/src/wren_utils.h
@@ -64,14 +64,14 @@ void wrenSymbolTableClear(WrenVM* vm, SymbolTable* symbols);
 
 // Adds name to the symbol table. Returns the index of it in the table.
 int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols,
-                       const char* name, int length);
+                       const char* name, uint32_t length);
 
 // Adds name to the symbol table. Returns the index of it in the table. Will
 // use an existing symbol if already present.
 int wrenSymbolTableEnsure(WrenVM* vm, SymbolTable* symbols,
-                          const char* name, int length);
+                          const char* name, uint32_t length);
 
 // Looks up name in the symbol table. Returns its index if found or -1 if not.
-int wrenSymbolTableFind(SymbolTable* symbols, const char* name, int length);
+int wrenSymbolTableFind(SymbolTable* symbols, const char* name, uint32_t length);
 
 #endif

--- a/src/wren_utils.h
+++ b/src/wren_utils.h
@@ -64,14 +64,14 @@ void wrenSymbolTableClear(WrenVM* vm, SymbolTable* symbols);
 
 // Adds name to the symbol table. Returns the index of it in the table.
 int wrenSymbolTableAdd(WrenVM* vm, SymbolTable* symbols,
-                       const char* name, size_t length);
+                       const char* name, int length);
 
 // Adds name to the symbol table. Returns the index of it in the table. Will
 // use an existing symbol if already present.
 int wrenSymbolTableEnsure(WrenVM* vm, SymbolTable* symbols,
-                          const char* name, size_t length);
+                          const char* name, int length);
 
 // Looks up name in the symbol table. Returns its index if found or -1 if not.
-int wrenSymbolTableFind(SymbolTable* symbols, const char* name, size_t length);
+int wrenSymbolTableFind(SymbolTable* symbols, const char* name, int length);
 
 #endif

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -369,8 +369,8 @@ static uint32_t hashObject(Obj* object)
       // towards the prefix or suffix of the string. So sample up to eight
       // characters spread throughout the string.
       // TODO: Tune this.
-      uint32_t step = 1 + 7 / string->length;
-      for (uint32_t i = 0; i < string->length; i += step)
+      int step = 1 + 7 / string->length;
+      for (int i = 0; i < string->length; i += step)
       {
         hash ^= string->value[i];
         hash *= 16777619;
@@ -596,7 +596,7 @@ Value wrenNewRange(WrenVM* vm, double from, double to, bool isInclusive)
   return OBJ_VAL(range);
 }
 
-Value wrenNewString(WrenVM* vm, const char* text, size_t length)
+Value wrenNewString(WrenVM* vm, const char* text, int length)
 {
   // Allow NULL if the string is empty since byte buffers don't allocate any
   // characters for a zero-length string.
@@ -613,19 +613,19 @@ Value wrenNewString(WrenVM* vm, const char* text, size_t length)
   return OBJ_VAL(string);
 }
 
-Value wrenNewUninitializedString(WrenVM* vm, size_t length)
+Value wrenNewUninitializedString(WrenVM* vm, int length)
 {
   ObjString* string = ALLOCATE_FLEX(vm, ObjString, length + 1);
   initObj(vm, &string->obj, OBJ_STRING, vm->stringClass);
-  string->length = (int)length;
+  string->length = length;
 
   return OBJ_VAL(string);
 }
 
 ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right)
 {
-  size_t leftLength = strlen(left);
-  size_t rightLength = strlen(right);
+  int leftLength = strlen(left);
+  int rightLength = strlen(right);
 
   Value value = wrenNewUninitializedString(vm, leftLength + rightLength);
   ObjString* string = AS_STRING(value);

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -369,8 +369,8 @@ static uint32_t hashObject(Obj* object)
       // towards the prefix or suffix of the string. So sample up to eight
       // characters spread throughout the string.
       // TODO: Tune this.
-      int step = 1 + 7 / string->length;
-      for (int i = 0; i < string->length; i += step)
+      uint32_t step = 1 + 7 / string->length;
+      for (uint32_t i = 0; i < string->length; i += step)
       {
         hash ^= string->value[i];
         hash *= 16777619;
@@ -596,7 +596,7 @@ Value wrenNewRange(WrenVM* vm, double from, double to, bool isInclusive)
   return OBJ_VAL(range);
 }
 
-Value wrenNewString(WrenVM* vm, const char* text, int length)
+Value wrenNewString(WrenVM* vm, const char* text, uint32_t length)
 {
   // Allow NULL if the string is empty since byte buffers don't allocate any
   // characters for a zero-length string.
@@ -613,7 +613,7 @@ Value wrenNewString(WrenVM* vm, const char* text, int length)
   return OBJ_VAL(string);
 }
 
-Value wrenNewUninitializedString(WrenVM* vm, int length)
+Value wrenNewUninitializedString(WrenVM* vm, uint32_t length)
 {
   ObjString* string = ALLOCATE_FLEX(vm, ObjString, length + 1);
   initObj(vm, &string->obj, OBJ_STRING, vm->stringClass);
@@ -624,8 +624,8 @@ Value wrenNewUninitializedString(WrenVM* vm, int length)
 
 ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right)
 {
-  int leftLength = (int)strlen(left);
-  int rightLength = (int)strlen(right);
+  uint32_t leftLength = (uint32_t)strlen(left);
+  uint32_t rightLength = (uint32_t)strlen(right);
 
   Value value = wrenNewUninitializedString(vm, leftLength + rightLength);
   ObjString* string = AS_STRING(value);
@@ -636,9 +636,8 @@ ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right)
   return string;
 }
 
-Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, int index)
+Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, uint32_t index)
 {
-  ASSERT(index >= 0, "Index out of bounds.");
   ASSERT(index < string->length, "Index out of bounds.");
 
   char first = string->value[index];

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -624,8 +624,8 @@ Value wrenNewUninitializedString(WrenVM* vm, int length)
 
 ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right)
 {
-  int leftLength = strlen(left);
-  int rightLength = strlen(right);
+  int leftLength = (int)strlen(left);
+  int rightLength = (int)strlen(right);
 
   Value value = wrenNewUninitializedString(vm, leftLength + rightLength);
   ObjString* string = AS_STRING(value);

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -108,7 +108,7 @@ typedef struct
 {
   Obj obj;
   // Does not include the null terminator.
-  int length;
+  uint32_t length;
   char value[FLEXIBLE_ARRAY];
 } ObjString;
 
@@ -649,13 +649,13 @@ Value wrenNewRange(WrenVM* vm, double from, double to, bool isInclusive);
 // Creates a new string object of [length] and copies [text] into it.
 //
 // [text] may be NULL if [length] is zero.
-Value wrenNewString(WrenVM* vm, const char* text, int length);
+Value wrenNewString(WrenVM* vm, const char* text, uint32_t length);
 
 // Creates a new string object with a buffer large enough to hold a string of
 // [length] but does no initialization of the buffer.
 //
 // The caller is expected to fully initialize the buffer after calling.
-Value wrenNewUninitializedString(WrenVM* vm, int length);
+Value wrenNewUninitializedString(WrenVM* vm, uint32_t length);
 
 // Creates a new string that is the concatenation of [left] and [right].
 ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right);
@@ -663,7 +663,7 @@ ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right);
 // Creates a new string containing the code point in [string] starting at byte
 // [index]. If [index] points into the middle of a UTF-8 sequence, returns an
 // empty string.
-Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, int index);
+Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, uint32_t index);
 
 // Creates a new open upvalue pointing to [value] on the stack.
 Upvalue* wrenNewUpvalue(WrenVM* vm, Value* value);

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -649,13 +649,13 @@ Value wrenNewRange(WrenVM* vm, double from, double to, bool isInclusive);
 // Creates a new string object of [length] and copies [text] into it.
 //
 // [text] may be NULL if [length] is zero.
-Value wrenNewString(WrenVM* vm, const char* text, size_t length);
+Value wrenNewString(WrenVM* vm, const char* text, int length);
 
 // Creates a new string object with a buffer large enough to hold a string of
 // [length] but does no initialization of the buffer.
 //
 // The caller is expected to fully initialize the buffer after calling.
-Value wrenNewUninitializedString(WrenVM* vm, size_t length);
+Value wrenNewUninitializedString(WrenVM* vm, int length);
 
 // Creates a new string that is the concatenation of [left] and [right].
 ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right);

--- a/src/wren_vm.c
+++ b/src/wren_vm.c
@@ -332,7 +332,7 @@ static ObjString* methodNotFound(WrenVM* vm, ObjClass* classObj, int symbol)
   // method expects.
   const char* methodName = vm->methodNames.data[symbol];
 
-  int methodLength = strlen(methodName);
+  int methodLength = (int)strlen(methodName);
   int numParams = 0;
   while (methodName[methodLength - numParams - 1] == ' ') numParams++;
 
@@ -343,7 +343,7 @@ static ObjString* methodNotFound(WrenVM* vm, ObjClass* classObj, int symbol)
           numParams,
           numParams == 1 ? "" : "s");
 
-  return AS_STRING(wrenNewString(vm, message, strlen(message)));
+  return AS_STRING(wrenNewString(vm, message, (int)strlen(message)));
 }
 
 // Pushes [function] onto [fiber]'s callstack and invokes it. Expects [numArgs]
@@ -865,7 +865,7 @@ static bool runInterpreter(WrenVM* vm)
       if (!IS_CLASS(expected))
       {
         const char* message = "Right operand must be a class.";
-        RUNTIME_ERROR(AS_STRING(wrenNewString(vm, message, strlen(message))));
+        RUNTIME_ERROR(AS_STRING(wrenNewString(vm, message, (int)strlen(message))));
       }
 
       ObjClass* actual = wrenGetClass(vm, POP());
@@ -997,7 +997,7 @@ static bool runInterpreter(WrenVM* vm)
             "Class '%s' may not have more than %d fields, including inherited "
             "ones.", name->value, MAX_FIELDS);
 
-        RUNTIME_ERROR(AS_STRING(wrenNewString(vm, message, strlen(message))));
+        RUNTIME_ERROR(AS_STRING(wrenNewString(vm, message, (int)strlen(message))));
       }
 
       PUSH(OBJ_VAL(classObj));
@@ -1107,9 +1107,9 @@ static void defineMethod(WrenVM* vm, const char* className,
 {
   ASSERT(className != NULL, "Must provide class name.");
 
-  int length = strlen(methodName);
+  int length = (int)strlen(methodName);
   ASSERT(methodName != NULL, "Must provide method name.");
-  ASSERT(strlen(methodName) < MAX_METHOD_NAME, "Method name too long.");
+  ASSERT((int)strlen(methodName) < MAX_METHOD_NAME, "Method name too long.");
 
   ASSERT(numParams >= 0, "numParams cannot be negative.");
   ASSERT(numParams <= MAX_PARAMETERS, "Too many parameters.");
@@ -1118,7 +1118,7 @@ static void defineMethod(WrenVM* vm, const char* className,
 
   // Find or create the class to bind the method to.
   int classSymbol = wrenSymbolTableFind(&vm->globalNames,
-                               className, strlen(className));
+                               className, (int)strlen(className));
   ObjClass* classObj;
 
   if (classSymbol != -1)
@@ -1129,7 +1129,7 @@ static void defineMethod(WrenVM* vm, const char* className,
   else
   {
     // The class doesn't already exist, so create it.
-    int length = strlen(className);
+    int length = (int)strlen(className);
     ObjString* nameString = AS_STRING(wrenNewString(vm, className, length));
 
     wrenPushRoot(vm, (Obj*)nameString);
@@ -1231,7 +1231,7 @@ void wrenReturnString(WrenVM* vm, const char* text, int length)
   ASSERT(text != NULL, "String cannot be NULL.");
 
   int size = length;
-  if (length == -1) size = strlen(text);
+  if (length == -1) size = (int)strlen(text);
 
   *vm->foreignCallSlot = wrenNewString(vm, text, size);
   vm->foreignCallSlot = NULL;

--- a/src/wren_vm.c
+++ b/src/wren_vm.c
@@ -332,8 +332,8 @@ static ObjString* methodNotFound(WrenVM* vm, ObjClass* classObj, int symbol)
   // method expects.
   const char* methodName = vm->methodNames.data[symbol];
 
-  int methodLength = (int)strlen(methodName);
-  int numParams = 0;
+  uint32_t methodLength = (uint32_t)strlen(methodName);
+  uint32_t numParams = 0;
   while (methodName[methodLength - numParams - 1] == ' ') numParams++;
 
   char message[MAX_VARIABLE_NAME + MAX_METHOD_NAME + 49];
@@ -343,7 +343,7 @@ static ObjString* methodNotFound(WrenVM* vm, ObjClass* classObj, int symbol)
           numParams,
           numParams == 1 ? "" : "s");
 
-  return AS_STRING(wrenNewString(vm, message, (int)strlen(message)));
+  return AS_STRING(wrenNewString(vm, message, (uint32_t)strlen(message)));
 }
 
 // Pushes [function] onto [fiber]'s callstack and invokes it. Expects [numArgs]
@@ -865,7 +865,7 @@ static bool runInterpreter(WrenVM* vm)
       if (!IS_CLASS(expected))
       {
         const char* message = "Right operand must be a class.";
-        RUNTIME_ERROR(AS_STRING(wrenNewString(vm, message, (int)strlen(message))));
+        RUNTIME_ERROR(AS_STRING(wrenNewString(vm, message, (uint32_t)strlen(message))));
       }
 
       ObjClass* actual = wrenGetClass(vm, POP());
@@ -997,7 +997,7 @@ static bool runInterpreter(WrenVM* vm)
             "Class '%s' may not have more than %d fields, including inherited "
             "ones.", name->value, MAX_FIELDS);
 
-        RUNTIME_ERROR(AS_STRING(wrenNewString(vm, message, (int)strlen(message))));
+		RUNTIME_ERROR(AS_STRING(wrenNewString(vm, message, (uint32_t)strlen(message))));
       }
 
       PUSH(OBJ_VAL(classObj));
@@ -1107,9 +1107,9 @@ static void defineMethod(WrenVM* vm, const char* className,
 {
   ASSERT(className != NULL, "Must provide class name.");
 
-  int length = (int)strlen(methodName);
+  uint32_t length = (uint32_t)strlen(methodName);
   ASSERT(methodName != NULL, "Must provide method name.");
-  ASSERT((int)strlen(methodName) < MAX_METHOD_NAME, "Method name too long.");
+  ASSERT((uint32_t)strlen(methodName) < MAX_METHOD_NAME, "Method name too long.");
 
   ASSERT(numParams >= 0, "numParams cannot be negative.");
   ASSERT(numParams <= MAX_PARAMETERS, "Too many parameters.");
@@ -1118,7 +1118,7 @@ static void defineMethod(WrenVM* vm, const char* className,
 
   // Find or create the class to bind the method to.
   int classSymbol = wrenSymbolTableFind(&vm->globalNames,
-                               className, (int)strlen(className));
+                                        className, (uint32_t)strlen(className));
   ObjClass* classObj;
 
   if (classSymbol != -1)
@@ -1129,7 +1129,7 @@ static void defineMethod(WrenVM* vm, const char* className,
   else
   {
     // The class doesn't already exist, so create it.
-    int length = (int)strlen(className);
+    uint32_t length = (uint32_t)strlen(className);
     ObjString* nameString = AS_STRING(wrenNewString(vm, className, length));
 
     wrenPushRoot(vm, (Obj*)nameString);
@@ -1230,8 +1230,8 @@ void wrenReturnString(WrenVM* vm, const char* text, int length)
   ASSERT(vm->foreignCallSlot != NULL, "Must be in foreign call.");
   ASSERT(text != NULL, "String cannot be NULL.");
 
-  int size = length;
-  if (length == -1) size = (int)strlen(text);
+  uint32_t size = (uint32_t)length;
+  if (length == -1) size = (uint32_t)strlen(text);
 
   *vm->foreignCallSlot = wrenNewString(vm, text, size);
   vm->foreignCallSlot = NULL;

--- a/src/wren_vm.c
+++ b/src/wren_vm.c
@@ -332,7 +332,7 @@ static ObjString* methodNotFound(WrenVM* vm, ObjClass* classObj, int symbol)
   // method expects.
   const char* methodName = vm->methodNames.data[symbol];
 
-  int methodLength = (int)strlen(methodName);
+  int methodLength = strlen(methodName);
   int numParams = 0;
   while (methodName[methodLength - numParams - 1] == ' ') numParams++;
 
@@ -1049,7 +1049,7 @@ WrenInterpretResult wrenInterpret(WrenVM* vm, const char* sourcePath,
   }
 }
 
-int wrenDeclareGlobal(WrenVM* vm, const char* name, size_t length)
+int wrenDeclareGlobal(WrenVM* vm, const char* name, int length)
 {
   if (vm->globals.count == MAX_GLOBALS) return -2;
 
@@ -1057,7 +1057,7 @@ int wrenDeclareGlobal(WrenVM* vm, const char* name, size_t length)
   return wrenSymbolTableAdd(vm, &vm->globalNames, name, length);
 }
 
-int wrenDefineGlobal(WrenVM* vm, const char* name, size_t length, Value value)
+int wrenDefineGlobal(WrenVM* vm, const char* name, int length, Value value)
 {
   if (vm->globals.count == MAX_GLOBALS) return -2;
 
@@ -1107,7 +1107,7 @@ static void defineMethod(WrenVM* vm, const char* className,
 {
   ASSERT(className != NULL, "Must provide class name.");
 
-  int length = (int)strlen(methodName);
+  int length = strlen(methodName);
   ASSERT(methodName != NULL, "Must provide method name.");
   ASSERT(strlen(methodName) < MAX_METHOD_NAME, "Method name too long.");
 
@@ -1129,7 +1129,7 @@ static void defineMethod(WrenVM* vm, const char* className,
   else
   {
     // The class doesn't already exist, so create it.
-    size_t length = strlen(className);
+    int length = strlen(className);
     ObjString* nameString = AS_STRING(wrenNewString(vm, className, length));
 
     wrenPushRoot(vm, (Obj*)nameString);
@@ -1229,8 +1229,8 @@ void wrenReturnString(WrenVM* vm, const char* text, int length)
 {
   ASSERT(vm->foreignCallSlot != NULL, "Must be in foreign call.");
   ASSERT(text != NULL, "String cannot be NULL.");
-  
-  size_t size = length;
+
+  int size = length;
   if (length == -1) size = strlen(text);
 
   *vm->foreignCallSlot = wrenNewString(vm, text, size);

--- a/src/wren_vm.h
+++ b/src/wren_vm.h
@@ -283,13 +283,13 @@ void* wrenReallocate(WrenVM* vm, void* memory, size_t oldSize, size_t newSize);
 // Does not check to see if a global with that name is already declared or
 // defined. Returns the symbol for the new global or -2 if there are too many
 // globals defined.
-int wrenDeclareGlobal(WrenVM* vm, const char* name, size_t length);
+int wrenDeclareGlobal(WrenVM* vm, const char* name, int length);
 
 // Adds a new global named [name] to the global namespace.
 //
 // Returns the symbol for the new global, -1 if a global with the given name
 // is already defined, or -2 if there are too many globals defined.
-int wrenDefineGlobal(WrenVM* vm, const char* name, size_t length, Value value);
+int wrenDefineGlobal(WrenVM* vm, const char* name, int length, Value value);
 
 // Sets the current Compiler being run to [compiler].
 void wrenSetCompiler(WrenVM* vm, Compiler* compiler);


### PR DESCRIPTION
Here's the first change.

I switched to use 'int' as the reference type for string lengths, in place of 'size_t'.

I scanned throughout the code to find and change every string length usage (also on function signatures).