### PR TITLE
Symbols length in the symbol table

### DIFF
--- a/src/wren_debug.c
+++ b/src/wren_debug.c
@@ -92,7 +92,7 @@ static int debugPrintInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
     {
       int global = READ_SHORT();
       printf("%-16s %5d '%s'\n", "LOAD_GLOBAL", global,
-             vm->globalNames.data[global]);
+             vm->globalNames.data[global].buffer);
       break;
     }
 
@@ -100,7 +100,7 @@ static int debugPrintInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
     {
       int global = READ_SHORT();
       printf("%-16s %5d '%s'\n", "STORE_GLOBAL", global,
-             vm->globalNames.data[global]);
+             vm->globalNames.data[global].buffer);
       break;
     }
 
@@ -133,7 +133,7 @@ static int debugPrintInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
       int numArgs = bytecode[i - 1] - CODE_CALL_0;
       int symbol = READ_SHORT();
       printf("CALL_%-11d %5d '%s'\n", numArgs, symbol,
-             vm->methodNames.data[symbol]);
+             vm->methodNames.data[symbol].buffer);
       break;
     }
 
@@ -158,7 +158,7 @@ static int debugPrintInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
       int numArgs = bytecode[i - 1] - CODE_SUPER_0;
       int symbol = READ_SHORT();
       printf("SUPER_%-10d %5d '%s'\n", numArgs, symbol,
-             vm->methodNames.data[symbol]);
+             vm->methodNames.data[symbol].buffer);
       break;
     }
 
@@ -230,7 +230,7 @@ static int debugPrintInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
     {
       int symbol = READ_SHORT();
       printf("%-16s %5d '%s'\n", "METHOD_INSTANCE", symbol,
-             vm->methodNames.data[symbol]);
+             vm->methodNames.data[symbol].buffer);
       break;
     }
 
@@ -238,7 +238,7 @@ static int debugPrintInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
     {
       int symbol = READ_SHORT();
       printf("%-16s %5d '%s'\n", "METHOD_STATIC", symbol,
-             vm->methodNames.data[symbol]);
+             vm->methodNames.data[symbol].buffer);
       break;
     }
 

--- a/src/wren_utils.c
+++ b/src/wren_utils.c
@@ -54,7 +54,7 @@ int wrenSymbolTableFind(SymbolTable* symbols, const char* name, size_t length)
   for (int i = 0; i < symbols->count; i++)
   {
     if (symbols->data[i].length == length &&
-        strncmp(symbols->data[i].buffer, name, length) == 0) return i;
+        memcmp(symbols->data[i].buffer, name, length) == 0) return i;
   }
 
   return -1;

--- a/src/wren_utils.h
+++ b/src/wren_utils.h
@@ -6,6 +6,13 @@
 
 // Reusable data structures and other utility functions.
 
+// A simple structure to keep trace of the string length as long as its data
+// (including the null-terminator)
+typedef struct {
+  char *buffer;
+  int length;
+} String;
+
 // We need buffers of a few different types. To avoid lots of casting between
 // void* and back, we'll use the preprocessor as a poor man's generics and let
 // it generate a few type-specific ones.
@@ -50,7 +57,7 @@
 
 DECLARE_BUFFER(Byte, uint8_t);
 DECLARE_BUFFER(Int, int);
-DECLARE_BUFFER(String, char*);
+DECLARE_BUFFER(String, String);
 
 // TODO: Change this to use a map.
 typedef StringBuffer SymbolTable;

--- a/src/wren_utils.h
+++ b/src/wren_utils.h
@@ -9,7 +9,7 @@
 // A simple structure to keep trace of the string length as long as its data
 // (including the null-terminator)
 typedef struct {
-  char *buffer;
+  char* buffer;
   int length;
 } String;
 

--- a/src/wren_vm.c
+++ b/src/wren_vm.c
@@ -330,7 +330,7 @@ static ObjString* methodNotFound(WrenVM* vm, ObjClass* classObj, int symbol)
 {
   // Count the number of spaces to determine the number of parameters the
   // method expects.
-  const char* methodName = vm->methodNames.data[symbol];
+  const char* methodName = vm->methodNames.data[symbol].buffer;
 
   int methodLength = (int)strlen(methodName);
   int numParams = 0;


### PR DESCRIPTION
Just a minor optimization, by getting rid of `strlen()` when accessing the symbol-table.