### PR TITLE
Lists type to 'uint32_t'

### DIFF
--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -659,10 +659,10 @@ DEF_NATIVE(list_iterate)
 
   if (!validateInt(vm, args, 1, "Iterator")) return PRIM_ERROR;
 
-  int index = (int)AS_NUM(args[1]);
+  uint32_t index = (uint32_t)AS_NUM(args[1]);
 
   // Stop if we're out of bounds.
-  if (index < 0 || index >= list->count - 1) RETURN_FALSE;
+  if (index >= list->count - 1) RETURN_FALSE;
 
   // Otherwise, move to the next index.
   RETURN_NUM(index + 1);

--- a/src/wren_value.c
+++ b/src/wren_value.c
@@ -278,7 +278,7 @@ void wrenListAdd(WrenVM* vm, ObjList* list, Value value)
   list->elements[list->count++] = value;
 }
 
-void wrenListInsert(WrenVM* vm, ObjList* list, Value value, int index)
+void wrenListInsert(WrenVM* vm, ObjList* list, Value value, uint32_t index)
 {
   if (IS_OBJ(value)) wrenPushRoot(vm, AS_OBJ(value));
 
@@ -287,7 +287,7 @@ void wrenListInsert(WrenVM* vm, ObjList* list, Value value, int index)
   if (IS_OBJ(value)) wrenPopRoot(vm);
 
   // Shift items down.
-  for (int i = list->count; i > index; i--)
+  for (uint32_t i = list->count; i > index; i--)
   {
     list->elements[i] = list->elements[i - 1];
   }
@@ -296,14 +296,14 @@ void wrenListInsert(WrenVM* vm, ObjList* list, Value value, int index)
   list->count++;
 }
 
-Value wrenListRemoveAt(WrenVM* vm, ObjList* list, int index)
+Value wrenListRemoveAt(WrenVM* vm, ObjList* list, uint32_t index)
 {
   Value removed = list->elements[index];
 
   if (IS_OBJ(removed)) wrenPushRoot(vm, AS_OBJ(removed));
 
   // Shift items up.
-  for (int i = index; i < list->count - 1; i++)
+  for (uint32_t i = index; i < list->count - 1; i++)
   {
     list->elements[i] = list->elements[i + 1];
   }
@@ -766,7 +766,7 @@ static void markList(WrenVM* vm, ObjList* list)
 
   // Mark the elements.
   Value* elements = list->elements;
-  for (int i = 0; i < list->count; i++)
+  for (uint32_t i = 0; i < list->count; i++)
   {
     wrenMarkValue(vm, elements[i]);
   }

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -327,13 +327,11 @@ typedef struct
 {
   Obj obj;
 
-  // TODO: Make these uint32_t to match ObjMap, or vice versa.
-  
   // The number of elements allocated.
-  int capacity;
+  uint32_t capacity;
 
   // The number of items in the list.
-  int count;
+  uint32_t count;
 
   // Pointer to a contiguous array of [capacity] elements.
   Value* elements;
@@ -622,10 +620,10 @@ ObjList* wrenNewList(WrenVM* vm, int numElements);
 void wrenListAdd(WrenVM* vm, ObjList* list, Value value);
 
 // Inserts [value] in [list] at [index], shifting down the other elements.
-void wrenListInsert(WrenVM* vm, ObjList* list, Value value, int index);
+void wrenListInsert(WrenVM* vm, ObjList* list, Value value, uint32_t index);
 
 // Removes and returns the item at [index] from [list].
-Value wrenListRemoveAt(WrenVM* vm, ObjList* list, int index);
+Value wrenListRemoveAt(WrenVM* vm, ObjList* list, uint32_t index);
 
 // Creates a new empty map.
 ObjMap* wrenNewMap(WrenVM* vm);


### PR DESCRIPTION
Just to come to full circle, here's the modification for the list type, too.

I performed a benchmark regression test on a "unification" branch with all my recent pull-request, and here's the results
```
binary_trees - wren            ..........  2545  0.39s  107.32% relative to baseline
delta_blue - wren              ..........  4927  0.20s  104.56% relative to baseline
fib - wren                     ..........  1566  0.64s   96.72% relative to baseline
for - wren                     ..........  3671  0.27s  104.67% relative to baseline
method_call - wren             ..........  3340  0.30s  114.32% relative to baseline

```