### PR TITLE
Adding '\0' escape sequence for null characters.

### DIFF
--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -699,6 +699,7 @@ static void readString(Parser* parser)
       {
         case '"':  addStringChar(parser, '"'); break;
         case '\\': addStringChar(parser, '\\'); break;
+        case '0':  addStringChar(parser, '\0'); break;
         case 'a':  addStringChar(parser, '\a'); break;
         case 'b':  addStringChar(parser, '\b'); break;
         case 'f':  addStringChar(parser, '\f'); break;


### PR DESCRIPTION
With this (trivial) pull-request we'll be recognising the '\0' escape sequence, as well.