### PR TITLE
Changing string size type to 'uint32_t'.

### DIFF
--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -1216,7 +1216,7 @@ DEF_NATIVE(string_iterate)
   do
   {
     index++;
-    if (index >= string->length) RETURN_FALSE;
+    if ((uint32_t)index >= string->length) RETURN_FALSE;
   } while ((string->value[index] & 0xc0) == 0x80);
 
   RETURN_NUM(index);

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -110,7 +110,7 @@ typedef struct
 {
   Obj obj;
   // Does not include the null terminator.
-  int length;
+  uint32_t length;
   char value[FLEXIBLE_ARRAY];
 } ObjString;
 


### PR DESCRIPTION
Another trivial one. We are changing the internal string length type to `uint32_t`.

This is a precondition to the next changes.