### PR TITLE
Replacing 'strstr()' with 'wrenStringFind()'

### DIFF
--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -1159,7 +1159,7 @@ DEF_NATIVE(string_contains)
   // Corner case, the empty string contains the empty string.
   if (string->length == 0 && search->length == 0) RETURN_TRUE;
 
-  RETURN_BOOL(strstr(string->value, search->value) != NULL);
+  RETURN_BOOL(wrenStringFind(vm, string, search) != string->length);
 }
 
 DEF_NATIVE(string_count)
@@ -1191,9 +1191,9 @@ DEF_NATIVE(string_indexOf)
   ObjString* string = AS_STRING(args[0]);
   ObjString* search = AS_STRING(args[1]);
 
-  char* firstOccurrence = strstr(string->value, search->value);
+  uint32_t index = wrenStringFind(vm, string, search);
 
-  RETURN_NUM(firstOccurrence ? firstOccurrence - string->value : -1);
+  RETURN_NUM(index == string->length ? -1 : (int)index);
 }
 
 DEF_NATIVE(string_iterate)

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -1156,8 +1156,8 @@ DEF_NATIVE(string_contains)
   ObjString* string = AS_STRING(args[0]);
   ObjString* search = AS_STRING(args[1]);
 
-  // Corner case, the empty string contains the empty string.
-  if (string->length == 0 && search->length == 0) RETURN_TRUE;
+  // Corner case, the empty string is always contained.
+  if (search->length == 0) RETURN_TRUE;
 
   RETURN_BOOL(wrenStringFind(vm, string, search) != string->length);
 }

--- a/src/wren_value.h
+++ b/src/wren_value.h
@@ -667,6 +667,11 @@ ObjString* wrenStringConcat(WrenVM* vm, const char* left, const char* right);
 // empty string.
 Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, int index);
 
+// Search for the first occurence of [needle] within [haystack] and returns its
+// zero-based offset. Returns [haystack->length] if [haystack] does not contain
+// [needle].
+uint32_t wrenStringFind(WrenVM* vm, ObjString* haystack, ObjString* needle);
+
 // Creates a new open upvalue pointing to [value] on the stack.
 Upvalue* wrenNewUpvalue(WrenVM* vm, Value* value);
 


### PR DESCRIPTION
In a single commit/pull-request we are getting rid of "strstr()" and using the new function, implementing BMH.