### PR TITLE
```make clean``` now removes the libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ RELEASE_CPP_LIB_OBJECTS := $(subst build/release-cpp/main.o,,$(RELEASE_CPP_OBJEC
 all: release
 
 clean:
-	@rm -rf build wren wrend libwren libwrend
+	@rm -rf build wren wrend libwren* libwrend*
 
 prep:
 	@mkdir -p build/debug build/release build/release-cpp

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ RELEASE_CPP_LIB_OBJECTS := $(subst build/release-cpp/main.o,,$(RELEASE_CPP_OBJEC
 all: release
 
 clean:
-	@rm -rf build wren wrend libwren* libwrend*
+	@rm -rf build
+	@rm -rf wren libwren.a libwren.so
+	@rm -rf wrend libwrend.a libwrend.so
 
 prep:
 	@mkdir -p build/debug build/release build/release-cpp


### PR DESCRIPTION
```make clean``` now removes ```libwren.a``` and ```libwren.so``` where it only removed ```build``` and ```wren``` before.