### PR TITLE
Benchmark script

### DIFF
--- a/benchmark/maps.lua
+++ b/benchmark/maps.lua
@@ -1,0 +1,19 @@
+local start = os.clock()
+
+local map = {}
+
+for i = 1, 100000 do
+  map[i] = i
+end
+
+local sum = 0
+for i = 1, 100000 do
+  sum = sum + map[i]
+end
+io.write(string.format("%d\n", sum))
+
+for i = 1, 100000 do
+  map[i] = nil
+end
+
+io.write(string.format("elapsed: %.8f\n", os.clock() - start))

--- a/benchmark/maps.py
+++ b/benchmark/maps.py
@@ -1,0 +1,20 @@
+from __future__ import print_function
+
+import time
+
+map = {}
+
+start = time.clock()
+
+for i in range(1, 100001):
+  map[i] = i
+
+sum = 0
+for i in range(1, 100001):
+  sum = sum + map[i]
+print(sum)
+
+for i in range(1, 100001):
+  del map[i]
+
+print("elapsed: " + str(time.clock() - start))

--- a/benchmark/maps.rb
+++ b/benchmark/maps.rb
@@ -1,0 +1,19 @@
+map = Hash.new
+
+start = Time.now
+
+for i in (1..100000)
+  map[i] = i
+end
+
+sum = 0
+for i in (1..100000)
+  sum = sum + map[i]
+end
+puts sum
+
+for i in (1..100000)
+  map.delete(i)
+end
+
+puts "elapsed: " + (Time.now - start).to_s

--- a/benchmark/maps.wren
+++ b/benchmark/maps.wren
@@ -1,0 +1,19 @@
+var start = IO.clock
+
+var map = {}
+
+for (i in 1..100000) {
+  map[i] = i
+}
+
+var sum = 0
+for (i in 1..100000) {
+  sum = sum + map[i]
+}
+IO.print(sum)
+
+for (i in 1..100000) {
+  map.remove(i)
+}
+
+IO.print("elapsed: ", IO.clock - start)

--- a/script/run_bench.py
+++ b/script/run_bench.py
@@ -44,6 +44,8 @@ BENCHMARK("for", r"""499999500000""")
 BENCHMARK("method_call", r"""true
 false""")
 
+BENCHMARK("maps", r"""5000050000""")
+
 LANGUAGES = [
   ("wren",           [os.path.join(HOME_DIR, 'wren')], ".wren"),
   ("lua",            ["lua"],                          ".lua"),

--- a/script/run_bench.py
+++ b/script/run_bench.py
@@ -11,8 +11,8 @@ import subprocess
 import sys
 
 # Runs the tests.
-WREN_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-BENCHMARK_DIR = os.path.join(WREN_DIR, 'benchmark')
+HOME_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+BENCHMARK_DIR = os.path.join(HOME_DIR, 'benchmark')
 
 # How many times to run a given benchmark.
 NUM_TRIALS = 10
@@ -45,12 +45,12 @@ BENCHMARK("method_call", r"""true
 false""")
 
 LANGUAGES = [
-  ("wren",           ["../wren"], ".wren"),
-  ("lua",            ["lua"],                   ".lua"),
-  ("luajit (-joff)", ["luajit", "-joff"],       ".lua"),
-  ("python",         ["python"],                ".py"),
-  ("python3",        ["python3"],               ".py"),
-  ("ruby",           ["ruby"],                  ".rb")
+  ("wren",           [os.path.join(HOME_DIR, 'wren')], ".wren"),
+  ("lua",            ["lua"],                          ".lua"),
+  ("luajit (-joff)", ["luajit", "-joff"],              ".lua"),
+  ("python",         ["python"],                       ".py"),
+  ("python3",        ["python3"],                      ".py"),
+  ("ruby",           ["ruby"],                         ".rb")
 ]
 
 results = {}


### PR DESCRIPTION
As we discussed some days ago, I moved (and renamed) the benchmark driver script to the `script` folder.

Also, I added some simple map benchmark scripts (very basic, just to have some kind of comparison with other languages). Oddlily, on my setup `luajit` gives a wrong result... :question: 

For the sake of curiosity, here's the "splitted" benchmark results I get
```
INSERT
wren   0.117443
python 0.013316
ruby   0.036993835
lua    0.00715400

LOOKUP
wren   0.021521
python 0.017457
ruby   0.0208651
lua    0.00565200

REMOVE
wren   0.189044
python 0.00957
ruby   0.017944434
lua    0.00477000
```
The benchmark scripts, however, calculate just the cumulative INSERT/LOOKUP/REMOVE time.

*(string benchmarks will follow in the next days)*