### PR TITLE
More bitwise operands

### DIFF
--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -52,8 +52,8 @@ typedef enum
   TOKEN_PERCENT,
   TOKEN_PLUS,
   TOKEN_MINUS,
-  TOKEN_LEFT_SHIFT,
-  TOKEN_RIGHT_SHIFT,
+  TOKEN_LTLT,
+  TOKEN_GTGT,
   TOKEN_PIPE,
   TOKEN_PIPEPIPE,
   TOKEN_CARET,
@@ -815,7 +815,7 @@ static void nextToken(Parser* parser)
         if (peekChar(parser) == '<')
         {
           nextChar(parser);
-          makeToken(parser, TOKEN_LEFT_SHIFT);
+          makeToken(parser, TOKEN_LTLT);
         }
         else
         {
@@ -827,7 +827,7 @@ static void nextToken(Parser* parser)
         if (peekChar(parser) == '>')
         {
           nextChar(parser);
-          makeToken(parser, TOKEN_RIGHT_SHIFT);
+          makeToken(parser, TOKEN_GTGT);
         }
         else
         {
@@ -2305,8 +2305,8 @@ GrammarRule rules[] =
   /* TOKEN_PERCENT       */ INFIX_OPERATOR(PREC_FACTOR, "% "),
   /* TOKEN_PLUS          */ INFIX_OPERATOR(PREC_TERM, "+ "),
   /* TOKEN_MINUS         */ OPERATOR("- "),
-  /* TOKEN_LEFT_SHIFT    */ INFIX_OPERATOR(PREC_BITWISE, "<< "),
-  /* TOKEN_RIGHT_SHIFT   */ INFIX_OPERATOR(PREC_BITWISE, ">> "),
+  /* TOKEN_LTLT          */ INFIX_OPERATOR(PREC_BITWISE, "<< "),
+  /* TOKEN_GTGT          */ INFIX_OPERATOR(PREC_BITWISE, ">> "),
   /* TOKEN_PIPE          */ INFIX_OPERATOR(PREC_BITWISE, "| "),
   /* TOKEN_PIPEPIPE      */ INFIX(PREC_LOGIC, or_),
   /* TOKEN_CARET         */ INFIX_OPERATOR(PREC_BITWISE, "^ "),

--- a/src/wren_compiler.c
+++ b/src/wren_compiler.c
@@ -52,8 +52,11 @@ typedef enum
   TOKEN_PERCENT,
   TOKEN_PLUS,
   TOKEN_MINUS,
+  TOKEN_LEFT_SHIFT,
+  TOKEN_RIGHT_SHIFT,
   TOKEN_PIPE,
   TOKEN_PIPEPIPE,
+  TOKEN_CARET,
   TOKEN_AMP,
   TOKEN_AMPAMP,
   TOKEN_BANG,
@@ -800,16 +803,36 @@ static void nextToken(Parser* parser)
         twoCharToken(parser, '&', TOKEN_AMPAMP, TOKEN_AMP);
         return;
 
+      case '^':
+        makeToken(parser, TOKEN_CARET);
+        return;
+
       case '=':
         twoCharToken(parser, '=', TOKEN_EQEQ, TOKEN_EQ);
         return;
 
       case '<':
-        twoCharToken(parser, '=', TOKEN_LTEQ, TOKEN_LT);
+        if (peekChar(parser) == '<')
+        {
+          nextChar(parser);
+          makeToken(parser, TOKEN_LEFT_SHIFT);
+        }
+        else
+        {
+          twoCharToken(parser, '=', TOKEN_LTEQ, TOKEN_LT);
+        }
         return;
 
       case '>':
-        twoCharToken(parser, '=', TOKEN_GTEQ, TOKEN_GT);
+        if (peekChar(parser) == '>')
+        {
+          nextChar(parser);
+          makeToken(parser, TOKEN_RIGHT_SHIFT);
+        }
+        else
+        {
+          twoCharToken(parser, '=', TOKEN_GTEQ, TOKEN_GT);
+        }
         return;
 
       case '!':
@@ -1356,7 +1379,7 @@ typedef enum
   PREC_IS,         // is
   PREC_COMPARISON, // < > <= >=
   PREC_RANGE,      // .. ...
-  PREC_BITWISE,    // | &
+  PREC_BITWISE,    // | ^ & << >>
   PREC_TERM,       // + -
   PREC_FACTOR,     // * / %
   PREC_UNARY,      // unary - ! ~
@@ -2282,8 +2305,11 @@ GrammarRule rules[] =
   /* TOKEN_PERCENT       */ INFIX_OPERATOR(PREC_FACTOR, "% "),
   /* TOKEN_PLUS          */ INFIX_OPERATOR(PREC_TERM, "+ "),
   /* TOKEN_MINUS         */ OPERATOR("- "),
+  /* TOKEN_LEFT_SHIFT    */ INFIX_OPERATOR(PREC_BITWISE, "<< "),
+  /* TOKEN_RIGHT_SHIFT   */ INFIX_OPERATOR(PREC_BITWISE, ">> "),
   /* TOKEN_PIPE          */ INFIX_OPERATOR(PREC_BITWISE, "| "),
   /* TOKEN_PIPEPIPE      */ INFIX(PREC_LOGIC, or_),
+  /* TOKEN_CARET         */ INFIX_OPERATOR(PREC_BITWISE, "^ "),
   /* TOKEN_AMP           */ INFIX_OPERATOR(PREC_BITWISE, "& "),
   /* TOKEN_AMPAMP        */ INFIX(PREC_LOGIC, and_),
   /* TOKEN_BANG          */ PREFIX_OPERATOR("!"),

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -1019,7 +1019,7 @@ DEF_NATIVE(num_bitwiseXor)
   RETURN_NUM(left ^ right);
 }
 
-DEF_NATIVE(num_bitwiseLsh)
+DEF_NATIVE(num_bitwiseLeftShift)
 {
   if (!validateNum(vm, args, 1, "Right operand")) return PRIM_ERROR;
 
@@ -1029,7 +1029,7 @@ DEF_NATIVE(num_bitwiseLsh)
   RETURN_NUM(left << right);
 }
 
-DEF_NATIVE(num_bitwiseRsh)
+DEF_NATIVE(num_bitwiseRightShift)
 {
   if (!validateNum(vm, args, 1, "Right operand")) return PRIM_ERROR;
 
@@ -1468,8 +1468,8 @@ void wrenInitializeCore(WrenVM* vm)
   NATIVE(vm->numClass, "& ", num_bitwiseAnd);
   NATIVE(vm->numClass, "| ", num_bitwiseOr);
   NATIVE(vm->numClass, "^ ", num_bitwiseXor);
-  NATIVE(vm->numClass, "<< ", num_bitwiseLsh);
-  NATIVE(vm->numClass, ">> ", num_bitwiseRsh);
+  NATIVE(vm->numClass, "<< ", num_bitwiseLeftShift);
+  NATIVE(vm->numClass, ">> ", num_bitwiseRightShift);
   NATIVE(vm->numClass, ".. ", num_dotDot);
   NATIVE(vm->numClass, "... ", num_dotDotDot);
   NATIVE(vm->numClass, "abs", num_abs);

--- a/src/wren_core.c
+++ b/src/wren_core.c
@@ -1009,6 +1009,36 @@ DEF_NATIVE(num_bitwiseOr)
   RETURN_NUM(left | right);
 }
 
+DEF_NATIVE(num_bitwiseXor)
+{
+  if (!validateNum(vm, args, 1, "Right operand")) return PRIM_ERROR;
+
+  // Bitwise operators always work on 32-bit unsigned ints.
+  uint32_t left = (uint32_t)AS_NUM(args[0]);
+  uint32_t right = (uint32_t)AS_NUM(args[1]);
+  RETURN_NUM(left ^ right);
+}
+
+DEF_NATIVE(num_bitwiseLsh)
+{
+  if (!validateNum(vm, args, 1, "Right operand")) return PRIM_ERROR;
+
+  // Bitwise operators always work on 32-bit unsigned ints.
+  uint32_t left = (uint32_t)AS_NUM(args[0]);
+  uint32_t right = (uint32_t)AS_NUM(args[1]);
+  RETURN_NUM(left << right);
+}
+
+DEF_NATIVE(num_bitwiseRsh)
+{
+  if (!validateNum(vm, args, 1, "Right operand")) return PRIM_ERROR;
+
+  // Bitwise operators always work on 32-bit unsigned ints.
+  uint32_t left = (uint32_t)AS_NUM(args[0]);
+  uint32_t right = (uint32_t)AS_NUM(args[1]);
+  RETURN_NUM(left >> right);
+}
+
 DEF_NATIVE(num_dotDot)
 {
   if (!validateNum(vm, args, 1, "Right hand side of range")) return PRIM_ERROR;
@@ -1437,6 +1467,9 @@ void wrenInitializeCore(WrenVM* vm)
   NATIVE(vm->numClass, "~", num_bitwiseNot);
   NATIVE(vm->numClass, "& ", num_bitwiseAnd);
   NATIVE(vm->numClass, "| ", num_bitwiseOr);
+  NATIVE(vm->numClass, "^ ", num_bitwiseXor);
+  NATIVE(vm->numClass, "<< ", num_bitwiseLsh);
+  NATIVE(vm->numClass, ">> ", num_bitwiseRsh);
   NATIVE(vm->numClass, ".. ", num_dotDot);
   NATIVE(vm->numClass, "... ", num_dotDotDot);
   NATIVE(vm->numClass, "abs", num_abs);

--- a/test/number/bitwise_lsh.wren
+++ b/test/number/bitwise_lsh.wren
@@ -1,0 +1,15 @@
+IO.print(0 << 0) // expect: 0
+IO.print(1 << 0) // expect: 1
+IO.print(0 << 1) // expect: 0
+IO.print(1 << 1) // expect: 2
+IO.print(2863311530 << 1) // expect: 1431655764
+IO.print(4042322160 << 1) // expect: 3789677024
+
+// Max u32 value.
+IO.print(4294967295 << 1) // expect: 4294967294
+
+// Past max u32 value.
+IO.print(4294967296 << 1) // expect: 0
+
+// TODO: Negative numbers.
+// TODO: Floating-point numbers.

--- a/test/number/bitwise_lsh_operand_not_num.wren
+++ b/test/number/bitwise_lsh_operand_not_num.wren
@@ -1,0 +1,1 @@
+1 << false // expect runtime error: Right operand must be a number.

--- a/test/number/bitwise_rsh.wren
+++ b/test/number/bitwise_rsh.wren
@@ -1,0 +1,15 @@
+IO.print(0 >> 0) // expect: 0
+IO.print(1 >> 0) // expect: 1
+IO.print(0 >> 1) // expect: 0
+IO.print(1 >> 1) // expect: 0
+IO.print(2863311530 >> 1) // expect: 1431655765
+IO.print(4042322160 >> 1) // expect: 2021161080
+
+// Max u32 value.
+IO.print(4294967295 >> 1) // expect: 2147483647
+
+// Past max u32 value.
+IO.print(4294967296 >> 1) // expect: 0
+
+// TODO: Negative numbers.
+// TODO: Floating-point numbers.

--- a/test/number/bitwise_rsh_operand_not_num.wren
+++ b/test/number/bitwise_rsh_operand_not_num.wren
@@ -1,0 +1,1 @@
+1 >> false // expect runtime error: Right operand must be a number.

--- a/test/number/bitwise_xor.wren
+++ b/test/number/bitwise_xor.wren
@@ -1,0 +1,15 @@
+IO.print(0 ^ 0) // expect: 0
+IO.print(1 ^ 1) // expect: 0
+IO.print(0 ^ 1) // expect: 1
+IO.print(1 ^ 0) // expect: 1
+IO.print(2863311530 ^ 1431655765) // expect: 4294967295
+IO.print(4042322160 ^ 1010580540) // expect: 3435973836
+
+// Max u32 value.
+IO.print(4294967295 ^ 4294967295) // expect: 0
+
+// Past max u32 value.
+IO.print(4294967296 ^ 4294967296) // expect: 0
+
+// TODO: Negative numbers.
+// TODO: Floating-point numbers.

--- a/test/number/bitwise_xor_operand_not_num.wren
+++ b/test/number/bitwise_xor_operand_not_num.wren
@@ -1,0 +1,1 @@
+1 ^ false // expect runtime error: Right operand must be a number.


### PR DESCRIPTION
This one should close #171.

I hope I guessed right the relative shifting-operands precedence... :wink: Let me know, in case.

Now, we can implement a `xorshift` PRNG in Wren! :+1: 