### PR TITLE
Initial implementation of raw/multiline strings

### DIFF
--- a/test/string/literals.wren
+++ b/test/string/literals.wren
@@ -3,3 +3,11 @@ IO.print("a string") // expect: a string
 
 // Non-ASCII.
 IO.print("A~¶Þॐஃ") // expect: A~¶Þॐஃ
+
+// Multiline/Raw
+IO.print([[ This is a raw \string ]]) // expect:  This is a raw \string 
+IO.print([[
+This shouldn't [[ start with a newline ]]
+]]) // expect: This shouldn't [[ start with a newline ]]
+    // expect: 
+


### PR DESCRIPTION
This implementation of raw strings pretty much copies the Lua way exactly. The delimiters are the same, `[[` and `]]`, and can be nested arbitrarily. It also ignores the first character if it is a newline.