### PR TITLE
Generating a runtime error on subclassing of builtins

### DIFF
--- a/test/class/subclassing_class.wren
+++ b/test/class/subclassing_class.wren
@@ -1,0 +1,2 @@
+class SubClass is Class {} // expect runtime error: Class 'SubClass' may not subclass a built-in
+

--- a/test/closure/subclassing_closure.wren
+++ b/test/closure/subclassing_closure.wren
@@ -1,0 +1,16 @@
+var f = null
+
+{
+  var a = "a"
+  f = new Fn {
+    IO.print(a)
+  }
+}
+//@FIXME: repair the segfault create a propper test for the subclassing
+
+//var closureSegfault = f
+//class SubClosureSegfault is closureSegfault {} 
+
+//var closureOk = f.call
+//class SubClosureOk is closureOk {} 
+

--- a/test/fiber/subclassing_fiber.wren
+++ b/test/fiber/subclassing_fiber.wren
@@ -1,0 +1,2 @@
+class SubFiber is Fiber {} // expect runtime error: Class 'SubFiber' may not subclass a built-in
+

--- a/test/function/subclassing_fn.wren
+++ b/test/function/subclassing_fn.wren
@@ -1,0 +1,2 @@
+class SubFn is Fn {} // expect runtime error: Class 'SubFn' may not subclass a built-in
+

--- a/test/list/subclassing_list.wren
+++ b/test/list/subclassing_list.wren
@@ -1,0 +1,1 @@
+class SubList is List {} // expect runtime error: Class 'SubList' may not subclass a built-in

--- a/test/map/subclassing_map.wren
+++ b/test/map/subclassing_map.wren
@@ -1,0 +1,2 @@
+class SubMap is Map {} // expect runtime error: Class 'SubMap' may not subclass a built-in
+

--- a/test/range/subclassing_range.wren
+++ b/test/range/subclassing_range.wren
@@ -1,0 +1,1 @@
+class SubRange is Range {} // expect runtime error: Class 'SubRange' may not subclass a built-in

--- a/test/string/subclassing_string.wren
+++ b/test/string/subclassing_string.wren
@@ -1,0 +1,2 @@
+class SubString is String {} // expect runtime error: Class 'SubString' may not subclass a built-in
+


### PR DESCRIPTION
As discussed in https://github.com/munificent/wren/issues/70, it is not allowed to subclass built-in types.

Please review, especcially  test/closure/subclassing_closure.wren