### PR TITLE
doc: add documentation for ceil, floor, .., and ... in num.markdown

### DIFF
--- a/doc/site/core/num.markdown
+++ b/doc/site/core/num.markdown
@@ -1,8 +1,6 @@
 ^title Num Class
 ^category core
 
-**TODO**
-
 ### **abs**
 
 The absolute value of the number.
@@ -12,7 +10,10 @@ The absolute value of the number.
 
 ### **ceil**
 
-**TODO**
+Rounds the number up to the nearest integer.
+
+    :::dart
+    1.5.ceil // 2
 
 ### **cos**
 
@@ -20,7 +21,10 @@ The cosine of the number.
 
 ### **floor**
 
-**TODO**
+Round the number down to the nearest integer.
+
+    :::dart
+    1.5.floor // 1
 
 ### **isNan**
 
@@ -85,8 +89,26 @@ It is a runtime error if `other` is not a number.
 
 ### **..**(other) operator
 
-**TODO**
+Creates a [Range](core/range.html) representing a consecutive range of integers 
+from the beginning number to the ending number.
+
+    :::dart
+    for (i in 1..3) {
+        IO.print(i)
+    }
+    // 1
+    // 2
+    // 3
 
 ### **...**(other) operator
 
-**TODO**
+Creates a [Range](core/range.html) representing a consecutive range of integers 
+from the beginning number to the ending number not including the ending number.
+
+    :::dart
+    for (i in 1...3) {
+        IO.print(i)
+    }
+    // 1
+    // 2
+


### PR DESCRIPTION
I added documentation to num.markdown for ceil, floor, and the range operators.