### PR TITLE
Made the fib benchmark a bit faster

### DIFF
--- a/benchmark/fib.wren
+++ b/benchmark/fib.wren
@@ -1,10 +1,12 @@
-var fib = new Fn {|n|
-  if (n < 2) return n
-  return fib.call(n - 1) + fib.call(n - 2)
+class Fib {
+  static get(n) {
+    if (n < 2) return n
+    return get(n - 1) + get(n - 2)
+  }
 }
 
 var start = IO.clock
 for (i in 1..5) {
-  IO.print(fib.call(28))
+  IO.print(Fib.get(28))
 }
 IO.print("elapsed: ", IO.clock - start)


### PR DESCRIPTION
This way `fib.wren` was consistently about 6% faster for me.

Feel free to close this pull request if the alternative notation deviates too much from the other languages. I found it mainly interesting that apparently free functions are slower to work with than classes, at least in this case. It's probably because of the recursive calls saving one lookup?

Note that the `static` did not matter much in the benchmark at all, I only wrote that to simplify things. The same speed advantages was present when leaving it out and doing `var fib = new Fib` instead.