### PR TITLE
Fix unreachable links for IE11 (edge mode)

### DIFF
--- a/doc/site/style.scss
+++ b/doc/site/style.scss
@@ -156,6 +156,7 @@ a {
 main {
   @extend .main-column;
   padding-top: 12px;
+  float:left;
 }
 
 a:hover {


### PR DESCRIPTION
This corrects the flow of content. As main did not have a float style it
overlapped the nav tag making the links unreachable in IE11.