### PR TITLE
If module file can't be loaded try to load it as a module folder instead

### DIFF
--- a/src/cli/io.c
+++ b/src/cli/io.c
@@ -49,12 +49,12 @@ void setRootDirectory(const char* path)
   rootDirectory = path;
 }
 
-char* readModule(WrenVM* vm, const char* module)
+char* wrenFilePath(const char* name)
 {
   // The module path is relative to the root directory and with ".wren".
   size_t rootLength = rootDirectory == NULL ? 0 : strlen(rootDirectory);
-  size_t moduleLength = strlen(module);
-  size_t pathLength = rootLength + moduleLength + 5;
+  size_t nameLength = strlen(name);
+  size_t pathLength = rootLength + nameLength + 5;
   char* path = (char*)malloc(pathLength + 1);
 
   if (rootDirectory != NULL)
@@ -62,16 +62,41 @@ char* readModule(WrenVM* vm, const char* module)
     memcpy(path, rootDirectory, rootLength);
   }
 
-  memcpy(path + rootLength, module, moduleLength);
-  memcpy(path + rootLength + moduleLength, ".wren", 5);
+  memcpy(path + rootLength, name, nameLength);
+  memcpy(path + rootLength + nameLength, ".wren", 5);
   path[pathLength] = '\0';
 
-  char* file = readFile(path);
-  if (file == NULL)
+  return path;
+}
+
+char* readModule(WrenVM* vm, const char* module)
+{
+  // First try to load the module with a ".wren" extension.
+  char* modulePath = wrenFilePath(module);
+  char* moduleContents = readFile(modulePath);
+
+  // If no contents could be loaded treat the module name as specifying a
+  // package and try to load the "module.wren" file in the package.
+  if (moduleContents == NULL)
   {
-    free(path);
-    return NULL;
+    free(modulePath);
+
+    size_t moduleLength = strlen(module);
+    size_t modulePackageLength = moduleLength + 7;
+    char* packageModule = (char*)malloc(modulePackageLength + 1);
+    memcpy(packageModule, module, moduleLength);
+    memcpy(packageModule + moduleLength, "/module", 7);
+    packageModule[modulePackageLength] = '\0';
+
+    char* packageModulePath = wrenFilePath(packageModule);
+    moduleContents = readFile(packageModulePath);
+
+    if (moduleContents == NULL)
+    {
+      free(packageModulePath);
+      return NULL;
+    }
   }
 
-  return file;
+  return moduleContents;
 }

--- a/test/language/module/module_package/module.wren
+++ b/test/language/module/module_package/module.wren
@@ -1,0 +1,1 @@
+var Index = "index"

--- a/test/language/module/package_module.wren
+++ b/test/language/module/package_module.wren
@@ -1,0 +1,3 @@
+import "module_package" for Index
+
+IO.print(Index) // expect: index


### PR DESCRIPTION
This is a quick win that is self-contained in `main.c` to make module loading a little more powerful.