### PR TITLE
Added a check for allready freed in wrenFreeVm.

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -81,7 +81,7 @@ WrenVM* wrenNewVM(WrenConfiguration* configuration)
 
 void wrenFreeVM(WrenVM* vm)
 {
-  // TODO: Check for already freed.
+  if( vm == NULL || vm->methodNames.count == 0 ) return;
   // Free all of the GC objects.
   Obj* obj = vm->first;
   while (obj != NULL)


### PR DESCRIPTION
If wrenFreeVm was called twice, this would lead to an error, because the memory was allready freed.
The used check is rather naive, suggesting that a valid vm does have at least one methodName set.