### PR TITLE
Changed int-fields in ObjList to match the uint32_t-types in ObjMap

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -710,10 +710,10 @@ DEF_PRIMITIVE(list_iterate)
 
   if (!validateInt(vm, args, 1, "Iterator")) return PRIM_ERROR;
 
-  int index = (int)AS_NUM(args[1]);
+  uint32_t index = AS_NUM(args[1]);
 
   // Stop if we're out of bounds.
-  if (index < 0 || index >= list->count - 1) RETURN_FALSE;
+  if ( index >= list->count - 1) RETURN_FALSE;
 
   // Otherwise, move to the next index.
   RETURN_NUM(index + 1);

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -302,7 +302,7 @@ Value wrenListRemoveAt(WrenVM* vm, ObjList* list, int index)
   if (IS_OBJ(removed)) wrenPushRoot(vm, AS_OBJ(removed));
 
   // Shift items up.
-  for (int i = index; i < list->count - 1; i++)
+  for (uint32_t i = index; i < list->count - 1; i++)
   {
     list->elements[i] = list->elements[i + 1];
   }
@@ -940,7 +940,7 @@ static void markList(WrenVM* vm, ObjList* list)
 {
   // Mark the elements.
   Value* elements = list->elements;
-  for (int i = 0; i < list->count; i++)
+  for (uint32_t i = 0; i < list->count; i++)
   {
     wrenMarkValue(vm, elements[i]);
   }

--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -350,10 +350,10 @@ typedef struct
   // TODO: Make these uint32_t to match ObjMap, or vice versa.
 
   // The number of elements allocated.
-  int capacity;
+  uint32_t capacity;
 
   // The number of items in the list.
-  int count;
+  uint32_t count;
 
   // Pointer to a contiguous array of [capacity] elements.
   Value* elements;


### PR DESCRIPTION
Both ObjList and ObjMap have the same fields (capacity and count). Therefor it makes sense to make them the same type.