### PR TITLE
Added -Wextra to compile flags

### DIFF
--- a/script/wren.mk
+++ b/script/wren.mk
@@ -25,8 +25,8 @@ CLI_SOURCES  := $(wildcard src/cli/*.c)
 VM_SOURCES   := $(wildcard src/vm/*.c)
 BUILD_DIR := build
 
-CFLAGS := -Wall -Werror -Wsign-compare -Wtype-limits -Wuninitialized
-# TODO: Add -Wextra.
+CFLAGS := -Wall -Wextra -Werror -Wsign-compare -Wtype-limits -Wuninitialized -Wno-unused-parameter
+# TODO: dump '-Wno-unused-parameter'   
 
 # Mode configuration.
 ifeq ($(MODE),debug)

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1363,7 +1363,7 @@ void wrenReleaseMethod(WrenVM* vm, WrenMethod* method)
 }
 
 // Execute [source] in the context of the core module.
-WrenInterpretResult static loadIntoCore(WrenVM* vm, const char* source)
+static WrenInterpretResult loadIntoCore(WrenVM* vm, const char* source)
 {
   ObjModule* coreModule = getCoreModule(vm);
 


### PR DESCRIPTION
-Wextra does several extra checks during the compiling. Unfortunately one of the extra check is for unused parameters.
Several functions have unused parameters (mostly the WrenVM* vm).