### PR TITLE
Adds a Meta library with an eval function for interpreting code inline.

### DIFF
--- a/builtin/meta.wren
+++ b/builtin/meta.wren
@@ -1,0 +1,1 @@
+class Meta {}

--- a/script/test.py
+++ b/script/test.py
@@ -243,7 +243,7 @@ def run_test(path):
     print('')
 
 
-for dir in ['core', 'io', 'language', 'limit']:
+for dir in ['core', 'io', 'language', 'limit', 'meta']:
   walk(join(WREN_DIR, 'test', dir), run_test)
 
 print_line()

--- a/src/vm/wren_common.h
+++ b/src/vm/wren_common.h
@@ -51,6 +51,13 @@
 #define WREN_USE_LIB_IO 1
 #endif
 
+// If true, loads the "Meta" class in the standard library.
+//
+// Defaults to on.
+#ifndef WREN_USE_LIB_META
+#define WREN_USE_LIB_META 1
+#endif
+
 // These flags are useful for debugging and hacking on Wren itself. They are not
 // intended to be used for production code. They default to off.
 

--- a/src/vm/wren_meta.c
+++ b/src/vm/wren_meta.c
@@ -1,0 +1,21 @@
+#include "wren_meta.h"
+
+#if WREN_USE_LIB_META
+
+// This string literal is generated automatically from meta.wren. Do not edit.
+static const char* libSource =
+"class Meta {}\n";
+
+void metaEval(WrenVM* vm)
+{
+    const char* source = wrenGetArgumentString(vm, 1);
+    wrenInterpret(vm, "Meta", source);
+}
+
+void wrenLoadMetaLibrary(WrenVM* vm)
+{
+  wrenInterpret(vm, "", libSource);
+  wrenDefineStaticMethod(vm, "Meta", "eval(_)", metaEval);
+}
+
+#endif

--- a/src/vm/wren_meta.h
+++ b/src/vm/wren_meta.h
@@ -1,12 +1,8 @@
 #ifndef wren_meta_h
 #define wren_meta_h
 
-#include <stdio.h>
-
 #include "wren.h"
 #include "wren_common.h"
-#include "wren_value.h"
-#include "wren_vm.h"
 
 // This module defines the Meta class and its associated methods.
 #if WREN_USE_LIB_META

--- a/src/vm/wren_meta.h
+++ b/src/vm/wren_meta.h
@@ -1,0 +1,18 @@
+#ifndef wren_meta_h
+#define wren_meta_h
+
+#include <stdio.h>
+
+#include "wren.h"
+#include "wren_common.h"
+#include "wren_value.h"
+#include "wren_vm.h"
+
+// This module defines the Meta class and its associated methods.
+#if WREN_USE_LIB_META
+
+void wrenLoadMetaLibrary(WrenVM* vm);
+
+#endif
+
+#endif

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -14,6 +14,10 @@
   #include "wren_io.h"
 #endif
 
+#if WREN_USE_LIB_META
+  #include "wren_meta.h"
+#endif
+
 #if WREN_DEBUG_TRACE_MEMORY || WREN_DEBUG_TRACE_GC
   #include <time.h>
 #endif
@@ -74,6 +78,9 @@ WrenVM* wrenNewVM(WrenConfiguration* configuration)
   wrenInitializeCore(vm);
   #if WREN_USE_LIB_IO
     wrenLoadIOLibrary(vm);
+  #endif
+  #if WREN_USE_LIB_META
+    wrenLoadMetaLibrary(vm);
   #endif
 
   return vm;

--- a/test/meta/eval_existing_scoped_variable.wren
+++ b/test/meta/eval_existing_scoped_variable.wren
@@ -1,0 +1,5 @@
+var y
+
+Meta.eval("y = 2")
+
+IO.print(y) // expect: 2


### PR DESCRIPTION
This PR adds a simple `Meta.eval(_)` function that accepts a string to evaluate inline. The biggest limitation right now is that you can't define new names inside the evalled source and then use those names afterwards because the compiler assumes those names aren't defined in the source and can't generate the correct bytecode for them.