### PR TITLE
Bind C methods to Wren using foreign declarations.

### DIFF
--- a/builtin/io.wren
+++ b/builtin/io.wren
@@ -93,4 +93,9 @@ class IO {
       IO.writeString_("[invalid toString]")
     }
   }
+
+  foreign static writeString_(string)
+  foreign static clock
+  foreign static time
+  foreign static read
 }

--- a/doc/site/syntax.markdown
+++ b/doc/site/syntax.markdown
@@ -28,8 +28,8 @@ Some people like to see all of the reserved words in a programming language in
 one lump. If you're one of those folks, here you go:
 
     :::dart
-    break class else false for if in is new null
-    return static super this true var while
+    break class else false for foreign if in is new
+    null return static super this true var while
 
 ## Identifiers
 

--- a/src/cli/vm.c
+++ b/src/cli/vm.c
@@ -8,6 +8,7 @@ WrenVM* createVM()
 {
   WrenConfiguration config;
 
+  config.bindForeignMethodFn = NULL;
   config.loadModuleFn = readModule;
 
   // Since we're running in a standalone process, be generous with memory.

--- a/src/vm/wren_io.c
+++ b/src/vm/wren_io.c
@@ -106,6 +106,11 @@ static const char* libSource =
 "      IO.writeString_(\"[invalid toString]\")\n"
 "    }\n"
 "  }\n"
+"\n"
+"  foreign static writeString_(string)\n"
+"  foreign static clock\n"
+"  foreign static time\n"
+"  foreign static read\n"
 "}\n";
 
 static void ioWriteString(WrenVM* vm)
@@ -138,10 +143,18 @@ static void ioTime(WrenVM* vm)
 void wrenLoadIOLibrary(WrenVM* vm)
 {
   wrenInterpret(vm, "", libSource);
-  wrenDefineStaticMethod(vm, "IO", "writeString_(_)", ioWriteString);
-  wrenDefineStaticMethod(vm, "IO", "clock", ioClock);
-  wrenDefineStaticMethod(vm, "IO", "time", ioTime);
-  wrenDefineStaticMethod(vm, "IO", "read", ioRead);
+}
+
+WrenForeignMethodFn wrenBindIOForeignMethod(WrenVM* vm, const char* className,
+                                            const char* signature)
+{
+  ASSERT(strcmp(className, "IO") == 0, "Should only have IO class.");
+  
+  if (strcmp(signature, "writeString_(_)") == 0) return ioWriteString;
+  if (strcmp(signature, "clock") == 0) return ioClock;
+  if (strcmp(signature, "time") == 0) return ioTime;
+  if (strcmp(signature, "read") == 0) return ioRead;
+  return NULL;
 }
 
 #endif

--- a/src/vm/wren_io.h
+++ b/src/vm/wren_io.h
@@ -10,6 +10,9 @@
 
 void wrenLoadIOLibrary(WrenVM* vm);
 
+WrenForeignMethodFn wrenBindIOForeignMethod(WrenVM* vm, const char* className,
+                                            const char* signature);
+
 #endif
 
 #endif

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -542,7 +542,7 @@ Value wrenMapRemoveKey(WrenVM* vm, ObjMap* map, Value key)
   return value;
 }
 
-ObjModule* wrenNewModule(WrenVM* vm)
+ObjModule* wrenNewModule(WrenVM* vm, ObjString* name)
 {
   ObjModule* module = ALLOCATE(vm, ObjModule);
 
@@ -553,6 +553,8 @@ ObjModule* wrenNewModule(WrenVM* vm)
 
   wrenSymbolTableInit(&module->variableNames);
   wrenValueBufferInit(&module->variables);
+
+  module->name = name;
 
   wrenPopRoot(vm);
   return module;
@@ -946,6 +948,8 @@ static void markModule(WrenVM* vm, ObjModule* module)
   {
     wrenMarkValue(vm, module->variables.data[i]);
   }
+
+  wrenMarkObj(vm, (Obj*)module->name);
 
   // Keep track of how much memory is still in use.
   vm->bytesAllocated += sizeof(ObjModule);

--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -283,6 +283,9 @@ typedef struct
   // Symbol table for the names of all module variables. Indexes here directly
   // correspond to entries in [variables].
   SymbolTable variableNames;
+
+  // The name of the module.
+  ObjString* name;
 } ObjModule;
 
 // A first-class function object. A raw ObjFn can be used and invoked directly
@@ -656,7 +659,7 @@ void wrenMapClear(WrenVM* vm, ObjMap* map);
 Value wrenMapRemoveKey(WrenVM* vm, ObjMap* map, Value key);
 
 // Creates a new module.
-ObjModule* wrenNewModule(WrenVM* vm);
+ObjModule* wrenNewModule(WrenVM* vm, ObjString* name);
 
 // Creates a new range from [from] to [to].
 Value wrenNewRange(WrenVM* vm, double from, double to, bool isInclusive);

--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -165,11 +165,19 @@ typedef enum
 
   // Define a method for symbol [arg]. The class receiving the method is popped
   // off the stack, then the function defining the body is popped.
+  //
+  // If a foreign method is being defined, the "function" will be a string
+  // identifying the foreign method. Otherwise, it will be a function or
+  // closure.
   CODE_METHOD_INSTANCE,
 
   // Define a method for symbol [arg]. The class whose metaclass will receive
   // the method is popped off the stack, then the function defining the body is
   // popped.
+  //
+  // If a foreign method is being defined, the "function" will be a string
+  // identifying the foreign method. Otherwise, it will be a function or
+  // closure.
   CODE_METHOD_STATIC,
 
   // Load the module whose name is stored in string constant [arg]. Pushes
@@ -270,6 +278,9 @@ struct WrenVM
   // During a foreign function call, this will contain the number of arguments
   // to the function.
   int foreignCallNumArgs;
+
+  // The function used to locate foreign functions.
+  WrenBindForeignMethodFn bindForeign;
 
   // The function used to load modules.
   WrenLoadModuleFn loadModule;


### PR DESCRIPTION
I've been hacking on this for a while and finally got it to a place I like. But, before I merge it in, I want to see what others think. This replaces the old `wrenDefineMethod` and `wrenDefineStaticMethod` functions in the embedding API. Instead, in your Wren code, you declare a method "foreign" (and don't give it a body), like:

```dart
class SomeClass {
  foreign someMethodDefinedInC
}
```

When Wren executes that class body, it invokes a callback you give it (`bindForeignMethodFn`) in your `WrenConfiguration`. Wren passes you the name of the module and class containing the method, as well as the method's full signature. Your job is to then return a pointer to a C function that implements that method.

In other words, foreign methods are *pulled* in by the VM at an appropriate time. I think this is a little cleaner that the old API that basically jammed methods into classes from outside, implicitly creating the class if needed.

You can see how this is used by looking at the IO built-in library.

Passing you the module name should help make this composable when people want to reuse multiple different modules that all define their own foreign methods. (However, the Wren CLI doesn't do anything useful with this capability yet.)

Thoughts?
