### PR TITLE
Fix wrong function call

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1347,7 +1347,7 @@ static ObjFn* endCompiler(Compiler* compiler,
   wrenPopRoot(compiler->parser->vm);
 
   #if WREN_DEBUG_DUMP_COMPILED_CODE
-    wrenDebugPrintCode(compiler->parser->vm, fn);
+    wrenDumpCode(compiler->parser->vm, fn);
   #endif
 
   return fn;


### PR DESCRIPTION
I set `WREN_DEBUG_DUMP_COMPILED_CODE` to `1` and then I couldn't compile wren because of:

```
❯ make
        cc src/cli/io.c                   -Os -std=c99 -fPIC
        cc src/cli/main.c                 -Os -std=c99 -fPIC
        cc src/cli/vm.c                   -Os -std=c99 -fPIC
        cc src/vm/wren_compiler.c         -Os -std=c99 -fPIC
src/vm/wren_compiler.c:1350:5: error: implicit declaration of function 'wrenDebugPrintCode' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    wrenDebugPrintCode(compiler->parser->vm, fn);
    ^
1 error generated.
make[1]: *** [build/release/vm/wren_compiler.o] Error 1
make: *** [release] Error 2
```

`wrenDebugPrintCode` was not defined in `wren_debug.h`. Better said, it was renamed in 287c6112603c4d39bd17f0d74544ee1dbe2440b5