### PR TITLE
Fixed char-subscripts warning

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -942,7 +942,7 @@ DEF_PRIMITIVE(num_fromString)
   double number = strtod(string->value, &end);
 
   // Skip past any trailing whitespace.
-  while (*end != '\0' && isspace(*end)) end++;
+  while (*((unsigned char*)end) != '\0' && isspace(*((unsigned char*)end))) end++;
 
   if (errno == ERANGE)
   {


### PR DESCRIPTION
Without this fix, `make` would always produce the following warning/error:
```
ComFreek@ComFreeks-PC /cygdrive/p/wren
$ make
make[1]: Entering directory '/cygdrive/p/wren'
        cc src/vm/wren_core.c             -Os -std=c99
src/vm/wren_core.c: In function ‘prim_num_fromString’:
src/vm/wren_core.c:945:3: error: array subscript has type ‘char’ [-Werror=char-subscripts]
   while (*end != '\0' && isspace(*end)) end++;
   ^
cc1: all warnings being treated as errors
script/wren.mk:128: recipe for target 'build/release/vm/wren_core.o' failed
make[1]: *** [build/release/vm/wren_core.o] Error 1
make[1]: Leaving directory '/cygdrive/p/wren'
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 2

ComFreek@ComFreeks-PC /cygdrive/p/wren
```

My system:
- Windows 8 Pro
- Cygwin with GCC 4.9.2
- Branch `master` of Wren, last commit is https://github.com/munificent/wren/commit/54ee4987d19c1b5ee16297ffd85a8e571bd7b954

**NOTE:** I am not really a C programmer, so the change could possibly introduce ugly and/or inefficient code :) Please counter-check!