### PR TITLE
Fix warning in clang 3.5 (-Wabsolute-value)

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -390,7 +390,7 @@ static uint32_t calculateRange(WrenVM* vm, Value* args, ObjRange* range,
   }
 
   uint32_t to = (uint32_t)value;
-  *length = abs(from - to) + 1;
+  *length = abs((int)(from - to)) + 1;
   *step = from < to ? 1 : -1;
   return from;
 }


### PR DESCRIPTION
Travis builds with clang 3.4, so the warning didn't appear there.