### PR TITLE
new typeof keyword

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Marco Lizza <marco.lizza@gmail.com>
 Raymond Sohn <raymondsohn@gmail.com>
 Thorbjørn Lindeijer <bjorn@lindeijer.nl>
 Patricio Mac Adden <patriciomacadden@gmail.com>
+Alexander Roper <minirop@gmail.com>

--- a/doc/site/syntax.markdown
+++ b/doc/site/syntax.markdown
@@ -29,7 +29,7 @@ one lump. If you're one of those folks, here you go:
 
     :::dart
     break class else false for foreign if import in is
-    new null return static super this true var while
+    new null return static super this true typeof var while
 
 ## Identifiers
 

--- a/src/vm/wren_debug.c
+++ b/src/vm/wren_debug.c
@@ -321,6 +321,10 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
       break;
     }
 
+    case CODE_TYPEOF:
+      printf("TYPEOF\n");
+      break;
+
     case CODE_END:
       printf("CODE_END\n");
       break;

--- a/src/vm/wren_opcodes.h
+++ b/src/vm/wren_opcodes.h
@@ -187,6 +187,9 @@ OPCODE(LOAD_MODULE)
 // error otherwise.
 OPCODE(IMPORT_VARIABLE)
 
+// Return the type of its argument
+OPCODE(TYPEOF)
+
 // This pseudo-instruction indicates the end of the bytecode. It should
 // always be preceded by a `CODE_RETURN`, so is never actually executed.
 OPCODE(END)

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1213,8 +1213,7 @@ static bool runInterpreter(WrenVM* vm)
       Value variable = POP();
 
       ObjClass * tmpClass = wrenGetClass(vm, variable);
-      const char * str = tmpClass->name->value;
-      PUSH(wrenNewString(vm, str, strlen(str)));
+      PUSH(wrenObjectToValue((Obj*)tmpClass));
 
       DISPATCH();
     }

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1208,6 +1208,17 @@ static bool runInterpreter(WrenVM* vm)
       DISPATCH();
     }
 
+    CASE_CODE(TYPEOF):
+    {
+      Value variable = POP();
+
+      ObjClass * tmpClass = wrenGetClass(vm, variable);
+      const char * str = tmpClass->name->value;
+      PUSH(wrenNewString(vm, str, strlen(str)));
+
+      DISPATCH();
+    }
+
     CASE_CODE(END):
       // A CODE_END should always be preceded by a CODE_RETURN. If we get here,
       // the compiler generated wrong code.

--- a/test/language/typeof/typeof_fields.wren
+++ b/test/language/typeof/typeof_fields.wren
@@ -1,0 +1,13 @@
+class Test {
+  new {
+    _intField = 42
+    __staticField = {}
+  }
+
+  check {
+    return typeof(_intField) == "Num" && typeof(__staticField) == "Map"
+  }
+}
+
+var t = new Test
+IO.print(t.check) // expect: true

--- a/test/language/typeof/typeof_fields.wren
+++ b/test/language/typeof/typeof_fields.wren
@@ -5,7 +5,7 @@ class Test {
   }
 
   check {
-    return typeof(_intField) == "Num" && typeof(__staticField) == "Map"
+    return typeof(_intField) == Num && typeof(__staticField) == Map
   }
 }
 

--- a/test/language/typeof/typeof_variables.wren
+++ b/test/language/typeof/typeof_variables.wren
@@ -1,0 +1,19 @@
+var m = {}
+var l = []
+var r = 1..2
+var x = 42
+
+var f = new Fn {
+}
+class Test {
+}
+var t = new Test
+var n
+
+IO.print(typeof(m) == "Map") // expect: true
+IO.print(typeof(l) == "List") // expect: true
+IO.print(typeof(r) == "Range") // expect: true
+IO.print(typeof(x) == "Num") // expect: true
+IO.print(typeof(f) == "Fn") // expect: true
+IO.print(typeof(t) == "Test") // expect: true
+IO.print(typeof(n) == "Null") // expect: true

--- a/test/language/typeof/typeof_variables.wren
+++ b/test/language/typeof/typeof_variables.wren
@@ -10,10 +10,10 @@ class Test {
 var t = new Test
 var n
 
-IO.print(typeof(m) == "Map") // expect: true
-IO.print(typeof(l) == "List") // expect: true
-IO.print(typeof(r) == "Range") // expect: true
-IO.print(typeof(x) == "Num") // expect: true
-IO.print(typeof(f) == "Fn") // expect: true
-IO.print(typeof(t) == "Test") // expect: true
-IO.print(typeof(n) == "Null") // expect: true
+IO.print(typeof(m) == Map) // expect: true
+IO.print(typeof(l) == List) // expect: true
+IO.print(typeof(r) == Range) // expect: true
+IO.print(typeof(x) == Num) // expect: true
+IO.print(typeof(f) == Fn) // expect: true
+IO.print(typeof(t) == Test) // expect: true
+IO.print(typeof(n) == Null) // expect: true


### PR DESCRIPTION
I've added a new keyword `typeof` that returns the type of the expression as a string (`typeof(4+3) == Num`). Can be useful for error messages:

```cpp
class Plane {
  pilot=(value) {
    if(!(value is Pilot)) {
      IO.print("Error: 'Pilot' expected got '", typeof(value), "'.")
    }
  }
}

var p = new Plane
p.pilot = 3 // print "Error: 'Pilot' expected got 'Num'."
```

if you (Bob or any Wren-user) have any comment, remark, anything, feel free!

ps: I couldn't run the tests (yay, windows!), but I assume I didn't broke anything and wrote the new tests properly.