### PR TITLE
Allow lists and maps with trailing comma

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1815,6 +1815,9 @@ static void map(Compiler* compiler, bool allowAssignment)
     {
       ignoreNewlines(compiler);
 
+      // Map with trailing comma.
+      if (peek(compiler) == TOKEN_RIGHT_BRACE) break;
+
       // Push a copy of the map since the subscript call will consume it.
       emit(compiler, CODE_DUP);
 

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1778,6 +1778,9 @@ static void list(Compiler* compiler, bool allowAssignment)
     {
       ignoreNewlines(compiler);
 
+      // List with trailing comma.
+      if (peek(compiler) == TOKEN_RIGHT_BRACKET) break;
+
       // Push a copy of the list since the add() call will consume it.
       emit(compiler, CODE_DUP);
 

--- a/test/language/list/trailing_comma.wren
+++ b/test/language/list/trailing_comma.wren
@@ -1,0 +1,7 @@
+var list = [
+  "a",
+  "b",
+]
+
+IO.print(list[0]) // expect: a
+IO.print(list[1]) // expect: b

--- a/test/language/list/trailing_comma.wren
+++ b/test/language/list/trailing_comma.wren
@@ -5,3 +5,8 @@ var list = [
 
 IO.print(list[0]) // expect: a
 IO.print(list[1]) // expect: b
+
+// Invalid syntax
+IO.print(new Fiber { Meta.eval("[,]")    }.try()) // expect: Could not compile source code.
+IO.print(new Fiber { Meta.eval("[1,,]")  }.try()) // expect: Could not compile source code.
+IO.print(new Fiber { Meta.eval("[1,,2]") }.try()) // expect: Could not compile source code.

--- a/test/language/map/trailing_comma.wren
+++ b/test/language/map/trailing_comma.wren
@@ -1,0 +1,7 @@
+var map = {
+  "a": 1,
+  "b": 2,
+}
+
+IO.print(map["a"]) // expect: 1
+IO.print(map["b"]) // expect: 2

--- a/test/language/map/trailing_comma.wren
+++ b/test/language/map/trailing_comma.wren
@@ -5,3 +5,9 @@ var map = {
 
 IO.print(map["a"]) // expect: 1
 IO.print(map["b"]) // expect: 2
+
+// Invalid syntax
+// Parentheses are necessary to have these interpret as maps and not as blocks.
+IO.print(new Fiber { Meta.eval("({,})")        }.try()) // expect: Could not compile source code.
+IO.print(new Fiber { Meta.eval("({1:1,,})")    }.try()) // expect: Could not compile source code.
+IO.print(new Fiber { Meta.eval("({1:1,,2:2})") }.try()) // expect: Could not compile source code.


### PR DESCRIPTION
This is useful for multi-line lists and maps as it allows shuffling/adding/removing lines without having to care about commas. It's also supported in other languages with braces such as C(++) and JS (although only in their newer variants).