### PR TITLE
Remove LOOP opcode and make jump offsets signed

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -975,11 +975,12 @@ static int emit(Compiler* compiler, int byte)
   return compiler->bytecode.count - 1;
 }
 
+
 // Emits one 16-bit argument, which will be written big endian.
 static void emitShort(Compiler* compiler, int arg)
 {
-  emit(compiler, (arg >> 8) & 0xff);
-  emit(compiler, arg & 0xff);
+  emit(compiler, ((uint16_t)arg >> 8) & 0xff);
+  emit(compiler, (uint16_t)arg & 0xff);
 }
 
 // Emits one bytecode instruction followed by a 8-bit argument. Returns the
@@ -2610,7 +2611,6 @@ static int getNumArguments(const uint8_t* bytecode, const Value* constants,
     case CODE_SUPER_15:
     case CODE_SUPER_16:
     case CODE_JUMP:
-    case CODE_LOOP:
     case CODE_JUMP_IF:
     case CODE_AND:
     case CODE_OR:
@@ -2669,7 +2669,7 @@ static void endLoop(Compiler* compiler)
 {
   int loopOffset = compiler->bytecode.count - compiler->loop->start + 2;
   // TODO: Check for overflow.
-  emitShortArg(compiler, CODE_LOOP, loopOffset);
+  emitShortArg(compiler, CODE_JUMP, -loopOffset);
 
   patchJump(compiler, compiler->loop->exitJump);
 

--- a/src/vm/wren_debug.c
+++ b/src/vm/wren_debug.c
@@ -227,13 +227,6 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
       break;
     }
 
-    case CODE_LOOP:
-    {
-      int offset = READ_SHORT();
-      printf("%-16s %5d to %d\n", "LOOP", offset, i - offset);
-      break;
-    }
-
     case CODE_JUMP_IF:
     {
       int offset = READ_SHORT();

--- a/src/vm/wren_opcodes.h
+++ b/src/vm/wren_opcodes.h
@@ -115,22 +115,18 @@ OPCODE(SUPER_14)
 OPCODE(SUPER_15)
 OPCODE(SUPER_16)
 
-// Jump the instruction pointer [arg] forward.
+// Jump the instruction pointer [arg] bytes forward or backward.
 OPCODE(JUMP)
 
-// Jump the instruction pointer [arg] backward. Pop and discard the top of
-// the stack.
-OPCODE(LOOP)
-
-// Pop and if not truthy then jump the instruction pointer [arg] forward.
+// Pop and if not truthy then jump the instruction pointer [arg] bytes forward or backward.
 OPCODE(JUMP_IF)
 
-// If the top of the stack is false, jump [arg] forward. Otherwise, pop and
-// continue.
+// If the top of the stack is false, jump [arg] bytes forward or backward.
+// Otherwise, pop and continue.
 OPCODE(AND)
 
-// If the top of the stack is non-false, jump [arg] forward. Otherwise, pop
-// and continue.
+// If the top of the stack is non-false, jump [arg] bytes forward or backward.
+// Otherwise, pop and continue.
 OPCODE(OR)
 
 // Pop [a] then [b] and push true if [b] is an instance of [a].

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -964,22 +964,14 @@ static bool runInterpreter(WrenVM* vm)
 
     CASE_CODE(JUMP):
     {
-      uint16_t offset = READ_SHORT();
+      int16_t offset = READ_SHORT();
       ip += offset;
-      DISPATCH();
-    }
-
-    CASE_CODE(LOOP):
-    {
-      // Jump back to the top of the loop.
-      uint16_t offset = READ_SHORT();
-      ip -= offset;
       DISPATCH();
     }
 
     CASE_CODE(JUMP_IF):
     {
-      uint16_t offset = READ_SHORT();
+      int16_t offset = READ_SHORT();
       Value condition = POP();
 
       if (IS_FALSE(condition) || IS_NULL(condition)) ip += offset;
@@ -988,7 +980,7 @@ static bool runInterpreter(WrenVM* vm)
 
     CASE_CODE(AND):
     {
-      uint16_t offset = READ_SHORT();
+      int16_t offset = READ_SHORT();
       Value condition = PEEK();
 
       if (IS_FALSE(condition) || IS_NULL(condition))
@@ -1006,7 +998,7 @@ static bool runInterpreter(WrenVM* vm)
 
     CASE_CODE(OR):
     {
-      uint16_t offset = READ_SHORT();
+      int16_t offset = READ_SHORT();
       Value condition = PEEK();
 
       if (IS_FALSE(condition) || IS_NULL(condition))


### PR DESCRIPTION
Removing the LOOP opcode and using a signed offset in the jump opcode makes the list of opcodes cleaner. I made the offset in all jump opcodes signed to have them uniform.

If the range is too short I would extend the argument.