### PR TITLE
Fix for memory leaks

### DIFF
--- a/src/cli/io.c
+++ b/src/cli/io.c
@@ -46,6 +46,10 @@ char* readFile(const char* path)
 
 void setRootDirectory(const char* path)
 {
+  if (rootDirectory != NULL)
+  {
+    free((void*)rootDirectory);
+  }
   rootDirectory = path;
 }
 

--- a/src/cli/vm.c
+++ b/src/cli/vm.c
@@ -48,6 +48,7 @@ void runFile(WrenBindForeignMethodFn bindForeign, const char* path)
 
   wrenFreeVM(vm);
   free(source);
+  setRootDirectory(NULL);
 
   // Exit with an error code if the script failed.
   if (result == WREN_RESULT_COMPILE_ERROR) exit(65); // EX_DATAERR.

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1280,6 +1280,7 @@ static void freeCompiler(Compiler* compiler)
 {
   wrenByteBufferClear(compiler->parser->vm, &compiler->bytecode);
   wrenIntBufferClear(compiler->parser->vm, &compiler->debugSourceLines);
+  wrenValueBufferClear(compiler->parser->vm, &compiler->constants);
 }
 
 // Finishes [compiler], which is compiling a function, method, or chunk of top
@@ -1316,6 +1317,9 @@ static ObjFn* endCompiler(Compiler* compiler,
                               debugName, debugNameLength,
                               compiler->debugSourceLines.data);
   wrenPushRoot(compiler->parser->vm, (Obj*)fn);
+
+  // Clear constants. The constants are copied by wrenNewFunction
+  wrenValueBufferClear(compiler->parser->vm, &compiler->constants);
 
   // In the function that contains this one, load the resulting function object.
   if (compiler->parent != NULL)

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -22,9 +22,25 @@
   #include <time.h>
 #endif
 
+static void* defaultReallocate(void* ptr, size_t new_size)
+{
+  // The behavior of realloc for size == 0 is implementation defined.
+  // It can return a non NULL pointer which must not be dereferenced but nether
+  // the less must be freed. When calling the wren reallocation function with
+  // size == 0 the memory pointed to ptr must be freed and NULL returned.
+  if (ptr == NULL && new_size == 0) return NULL;
+  if (ptr != NULL && new_size == 0)
+  {
+    free(ptr);
+    return NULL;
+  }
+
+  return realloc(ptr, new_size);
+}
+
 WrenVM* wrenNewVM(WrenConfiguration* configuration)
 {
-  WrenReallocateFn reallocate = realloc;
+  WrenReallocateFn reallocate = defaultReallocate;
   if (configuration->reallocateFn != NULL)
   {
     reallocate = configuration->reallocateFn;


### PR DESCRIPTION
Valgrind's memcheck showed me some memory leaks when running the wren cli so I tried to fix them.

The first is in the cli itself. It's not a serious one because the memory gets freed a soon a the programm exits. The memory allocated for the root directory path is not freed.

In the wren compiler the constants buffer data's ownership is not transfered to the new function but the constans are copied so the buffer's data must be freed.

The last one is debatable. According to the C Standard `realloc(NULL, size)` is the same as `malloc(size)`. When the memory for the internal data structures is allocated the previous memory (which defaults to NULL) is deallocated by calling `DEALLOCATE(vm, NULL)` this will invoke `realloc(NULL, 0)` which will behave like `malloc(0)` which can return (implementation defined) a pointer to a zero sized object which must not be dereferenced, but freed. By using the DEALLOCATE macro with a NULL ptr these objects leak (they are size 0 so not really a memory leak). I changed the default reallocate function to one which does the right thing.