### PR TITLE
Update VS project files to build with libuv and the timer module

### DIFF
--- a/project/msvc2013/wren/wren.vcxproj
+++ b/project/msvc2013/wren/wren.vcxproj
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)..\..\src\include</IncludePath>
-    <LibraryPath>$(SolutionDir)..\..\build\vs\$(Configuration)\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
+    <LibraryPath>$(SolutionDir)..\..\build\vs\$(Configuration)\;$(SolutionDir)..\..\build\libuv\Release\lib\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
     <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(SolutionDir)..\..\src\include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)..\..\build\vs\$(Configuration)\;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(SolutionDir)..\..\build\vs\$(Configuration)\;$(SolutionDir)..\..\build\libuv\Release\lib\;$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -58,12 +58,12 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\cli;..\..\..\src\module;..\..\..\include;..\..\..\build\libuv\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>wren_static_d.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wren_static_d.lib;libuv.lib;ws2_32.lib;psapi.lib;iphlpapi.lib;userenv.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -75,25 +75,27 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\cli;..\..\..\src\module;..\..\..\include;..\..\..\build\libuv\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>wren_static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wren_static.lib;libuv.lib;ws2_32.lib;psapi.lib;iphlpapi.lib;userenv.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\cli\io.c" />
     <ClCompile Include="..\..\..\src\cli\main.c" />
     <ClCompile Include="..\..\..\src\cli\vm.c" />
+    <ClCompile Include="..\..\..\src\module\timer.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\cli\io.h" />
     <ClInclude Include="..\..\..\src\cli\vm.h" />
     <ClInclude Include="..\..\..\src\include\wren.h" />
+    <ClInclude Include="..\..\..\src\module\timer.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\wren_lib\wren_lib.vcxproj">

--- a/project/msvc2013/wren/wren.vcxproj.filters
+++ b/project/msvc2013/wren/wren.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="..\..\..\src\cli\vm.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\module\timer.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\include\wren.h">
@@ -33,6 +36,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\cli\vm.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\module\timer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/script/libuv.py
+++ b/script/libuv.py
@@ -22,25 +22,15 @@ def ensure_dir(dir):
 
   os.makedirs(dir)
 
-def rmtree_onerror(func, path, exc_info):
-  """
-  Error handler for ``shutil.rmtree``.
-
-  If the error is due to an access error (read only file)
-  it attempts to add write permission and then retries.
-
-  If the error is for another reason it re-raises the error.
-
-  Usage : ``shutil.rmtree(path, onerror=rmtree_onerror)``
-  """
-  import stat
-  if not os.access(path, os.W_OK):
-    # Is the error an access error?
-    os.chmod(path, stat.S_IWUSR)
-    func(path)
+def remove_dir(dir):
+  """Recursively removes dir."""
+  
+  if platform.system() == "Windows":
+    # rmtree gives up on readonly files on Windows
+    # rd doesn't like paths with forward slashes
+    subprocess.check_call(['cmd', '/c', 'rd', '/s', '/q', dir.replace('/', '\\')])
   else:
-    raise
-
+    shutil.rmtree(LIB_UV_DIR)
 
 def download_libuv():
   """Clones libuv into build/libuv and checks out the right version."""
@@ -49,7 +39,7 @@ def download_libuv():
   # version number in this script changes.
   if os.path.isdir(LIB_UV_DIR):
     print("Cleaning output directory...")
-    shutil.rmtree(LIB_UV_DIR, onerror=rmtree_onerror)
+    remove_dir(LIB_UV_DIR)
 
   ensure_dir("build")
 


### PR DESCRIPTION
`shutil.rmtree` was failing to remove the .git directory because it's full of readonly files, so `rmtree_onerror` was added to try and get around that.

`scripts/libuv.py` isn't run on build right now because it currently does not check if libuv exists and has been built.