### PR TITLE
Fix some bugs in the libuv timer module

### DIFF
--- a/src/module/timer.c
+++ b/src/module/timer.c
@@ -70,8 +70,7 @@ char* timerGetSource()
 {
   size_t length = strlen(timerLibSource);
   char* copy = (char*)malloc(length + 1);
-  strncpy(copy, timerLibSource, length);
-  copy[length] = '\0';
+  strncpy(copy, timerLibSource, length + 1);
   
   return copy;
 }

--- a/src/module/timer.c
+++ b/src/module/timer.c
@@ -63,6 +63,7 @@ char* timerGetSource()
   size_t length = strlen(timerLibSource);
   char* copy = (char*)malloc(length + 1);
   strncpy(copy, timerLibSource, length);
+  copy[length] = '\0';
   
   return copy;
 }

--- a/src/module/timer.c
+++ b/src/module/timer.c
@@ -28,11 +28,19 @@ static const char* timerLibSource =
 // The Wren method to call when a timer has completed.
 static WrenMethod* resumeTimer;
 
+// Called by libuv when the timer finished closing.
+static void timerCloseCallback(uv_handle_t* handle)
+{
+  free(handle);
+}
+
 // Called by libuv when the timer has completed.
 static void timerCallback(uv_timer_t* handle)
 {
   WrenValue* fiber = (WrenValue*)handle->data;
-  free(handle);
+  
+  // Tell libuv that we don't need the timer anymore.
+  uv_close((uv_handle_t*)handle, timerCloseCallback);
 
   // Run the fiber that was sleeping.
   wrenCall(getVM(), resumeTimer, "v", fiber);


### PR DESCRIPTION
* `timerGetSource` was returning a string without setting its null terminator
* Timer handles were being freed when libuv still had access to them

With this and #292, Wren builds and runs all the timer tests successfully on Windows.