### PR TITLE
readme: Updated line count

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var adjectives = Fiber.new {
 while (!adjectives.isDone) IO.print(adjectives.call())
 ```
 
- *  **Wren is small.** The codebase is about [5,000 lines][src]. You can
+ *  **Wren is small.** The codebase is about [7,000 lines][src]. You can
     skim the whole thing in an afternoon. It's *small*, but not *dense*. It
     is readable and [lovingly-commented][nan].
 


### PR DESCRIPTION
The line count is actually around 7,000 (or 11,000 including blanks and comments):

```
~/wren $ cloc src/*/*.{c,h}
      26 text files.
      26 unique files.                              
       0 files ignored.

http://cloc.sourceforge.net v 1.60  T=0.08 s (344.3 files/s, 146330.5 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
C                               12           1471           1279           6102
C/C++ Header                    14            380            967            850
-------------------------------------------------------------------------------
SUM:                            26           1851           2246           6952
-------------------------------------------------------------------------------
```