### PR TITLE
Add Support for \U Style Unicode Escapes

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -702,10 +702,10 @@ static int readHexEscape(Parser* parser, int digits, const char* description)
   return value;
 }
 
-// Reads a four hex digit Unicode escape sequence in a string literal.
-static void readUnicodeEscape(Parser* parser, ByteBuffer* string)
+// Reads a hex digit Unicode escape sequence in a string literal.
+static void readUnicodeEscape(Parser* parser, ByteBuffer* string, int length)
 {
-  int value = readHexEscape(parser, 4, "Unicode");
+  int value = readHexEscape(parser, length, "Unicode");
 
   // Grow the buffer enough for the encoded result.
   int numBytes = wrenUtf8EncodeNumBytes(value);
@@ -750,8 +750,8 @@ static void readString(Parser* parser)
         case 'n':  wrenByteBufferWrite(parser->vm, &string, '\n'); break;
         case 'r':  wrenByteBufferWrite(parser->vm, &string, '\r'); break;
         case 't':  wrenByteBufferWrite(parser->vm, &string, '\t'); break;
-        case 'u':  readUnicodeEscape(parser, &string); break;
-          // TODO: 'U' for 8 octet Unicode escapes.
+        case 'u':  readUnicodeEscape(parser, &string, 4); break;
+        case 'U':  readUnicodeEscape(parser, &string, 8); break;
         case 'v':  wrenByteBufferWrite(parser->vm, &string, '\v'); break;
         case 'x':
           wrenByteBufferWrite(parser->vm, &string,

--- a/test/language/string/incomplete_long_unicode_escape.wren
+++ b/test/language/string/incomplete_long_unicode_escape.wren
@@ -1,0 +1,2 @@
+// expect error line 2
+"\U01F603"

--- a/test/language/string/unicode_escapes.wren
+++ b/test/language/string/unicode_escapes.wren
@@ -14,4 +14,11 @@ System.print("\u0b83")     // expect: ஃ
 System.print("\u00B6")     // expect: ¶
 System.print("\u00DE")     // expect: Þ
 
-// TODO: Syntax for Unicode escapes > 0xffff?
+// Big escapes:
+var smile = "\U0001F603"
+var byteSmile = "\xf0\x9f\x98\x83"
+System.print(byteSmile == smile) // expect: true
+
+System.print("<\U0001F64A>")       // expect: <🙊>
+System.print("<\U0001F680>")       // expect: <🚀>
+System.print("<\U00010318>")       // expect: <𐌘>

--- a/test/language/string/unicode_two_bytes_to_long_escape.wren
+++ b/test/language/string/unicode_two_bytes_to_long_escape.wren
@@ -1,0 +1,2 @@
+// expect error line 2
+"\U0060"


### PR DESCRIPTION
This allows funky things such as 🚀 and 😀 to be directly encoded in
Wren strings.

:sparkles: :rocket: :sparkles: 