### PR TITLE
Remove Recursive Mark from GC

### DIFF
--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -107,7 +107,7 @@ typedef struct sObjClass ObjClass;
 typedef struct sObj
 {
   ObjType type;
-  bool marked;
+  bool isDark;
 
   // The object's class.
   ObjClass* classObj;
@@ -747,11 +747,14 @@ void wrenMarkValue(WrenVM* vm, Value value);
 
 // Mark [obj] as reachable and still in use. This should only be called
 // during the sweep phase of a garbage collection.
-void wrenMarkObj(WrenVM* vm, Obj* obj);
+void wrenGrayObj(WrenVM* vm, Obj* obj);
 
 // Mark the values in [buffer] as reachable and still in use. This should only
 // be called during the sweep phase of a garbage collection.
 void wrenMarkBuffer(WrenVM* vm, ValueBuffer* buffer);
+
+// Expand the makred objects to all those reacable from the current state.
+void wrenDarkenObjs(WrenVM* vm);
 
 // Releases all memory owned by [obj], including [obj] itself.
 void wrenFreeObj(WrenVM* vm, Obj* obj);

--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -70,7 +70,7 @@ struct WrenVM
   Obj* first;
 
   // The 'gray' set for the garbage collector. This is the stack of unprocessed
-  // objects while a garbace collection pass is in process.
+  // objects while a garbage collection pass is in process.
   Obj** gray;
   int grayDepth;
   int maxGray;

--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -69,6 +69,12 @@ struct WrenVM
   // The first object in the linked list of all currently allocated objects.
   Obj* first;
 
+  // The 'gray' set for the garbage collector. This is the stack of unprocessed
+  // objects while a garbace collection pass is in process.
+  Obj** gray;
+  int grayDepth;
+  int maxGray;
+
   // The list of temporary roots. This is for temporary or new objects that are
   // not otherwise reachable but should not be collected.
   //

--- a/test/language/deeply_nested_gc.wren
+++ b/test/language/deeply_nested_gc.wren
@@ -1,0 +1,7 @@
+var head
+
+for (i in 1..400000) {
+  head = { "next" : head }
+}
+
+System.print("done") // expect: done

--- a/test/language/many_reallocations.wren
+++ b/test/language/many_reallocations.wren
@@ -1,0 +1,14 @@
+var found = []
+for (i in 1..1000) {
+  var foo = 1337
+  for (i in 1..1000) {
+    foo = { "a" : foo, "b": foo }
+  }
+  var bar = foo
+  for (i in 1..1000) {
+    bar = bar["a"]
+  }
+  found.add(bar)
+}
+System.print(found.all {|i| i == 1337}) // expect: true
+System.print("DONE!") // expect: DONE!


### PR DESCRIPTION
The previous GC implementation used a recursive mark method. This can
result in stack overflows when attempting to mark deeply nested objects (#280).

This is an initial look at removing the recursive mark method. I've added a
simple `GCState` object which keeps track of a list of 'gray' objects. Once
we have finished the initial mark of all the root objects we iterate through
the gray list, adding each objects referenced objects to the gray list.

This resolves #280 