### PR TITLE
Update Visual Studio projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,10 +23,6 @@ xcuserdata/
 !wren/
 !wren_lib/
 
-# Visual Studio intermediate files.
-Debug/
-Release/
-
 # Visual Studio cache files.
 ipch/
 *.aps

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,14 @@ test/benchmark/baseline.txt
 xcuserdata/
 *.xccheckout
 
+# Allow Visual Studio project files.
+!wren/
+!wren_lib/
+
+# Visual Studio intermediate files.
+Debug/
+Release/
+
 # Visual Studio cache files.
 ipch/
 *.aps

--- a/src/module/io.c
+++ b/src/module/io.c
@@ -9,6 +9,10 @@
 
 #include <stdio.h>
 
+#ifdef _WIN32
+  #include <fcntl.h>
+#endif
+
 static const int stdinDescriptor = 0;
 
 // Handle to Stdin.onData_(). Called when libuv provides data on stdin.
@@ -111,7 +115,7 @@ void fileOpen(WrenVM* vm)
   uv_fs_t* request = createRequest(wrenGetArgumentValue(vm, 2));
   
   // TODO: Allow controlling flags and modes.
-  uv_fs_open(getLoop(), request, path, O_RDONLY, S_IRUSR, openCallback);
+  uv_fs_open(getLoop(), request, path, O_RDONLY, 0, openCallback);
 }
 
 // Called by libuv when the stat call for size completes.
@@ -171,7 +175,7 @@ static void fileReadBytesCallback(uv_fs_t* request)
 {
   if (handleRequestError(request)) return;
 
-  uv_buf_t buffer = request->bufs[0];
+  uv_buf_t buffer = request->fs.info.bufs[0];
   WrenValue* fiber = freeRequest(request);
 
   // TODO: Having to copy the bytes here is a drag. It would be good if Wren's

--- a/src/module/io.c
+++ b/src/module/io.c
@@ -77,7 +77,8 @@ static bool handleRequestError(uv_fs_t* request)
 {
   if (request->result >= 0) return false;
   
-  WrenValue* fiber = (WrenValue*)request->data;
+  FileReqData* reqData = (FileReqData*)request->data;
+  WrenValue* fiber = (WrenValue*)reqData->fiber;
   schedulerResumeError(fiber, uv_strerror((int)request->result));
   uv_fs_req_cleanup(request);
   free(request);

--- a/util/msvc2013/wren/wren.vcxproj
+++ b/util/msvc2013/wren/wren.vcxproj
@@ -1,0 +1,112 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{EBF43135-4A7A-400A-8F23-DF49907025AA}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>wren</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)..\..\src\include</IncludePath>
+    <LibraryPath>$(SolutionDir)..\..\build\vs\$(Configuration)\;$(SolutionDir)..\..\util\deps\libuv\Release\lib\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
+    <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(SolutionDir)..\..\src\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)..\..\build\vs\$(Configuration)\;$(SolutionDir)..\..\util\deps\libuv\Release\lib\;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\cli;..\..\..\src\module;..\..\..\include;..\..\..\util\deps\libuv\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>wren_static_d.lib;libuv.lib;ws2_32.lib;psapi.lib;iphlpapi.lib;userenv.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\cli;..\..\..\src\module;..\..\..\include;..\..\..\util\deps\libuv\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>wren_static.lib;libuv.lib;ws2_32.lib;psapi.lib;iphlpapi.lib;userenv.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\cli\main.c" />
+    <ClCompile Include="..\..\..\src\cli\modules.c" />
+    <ClCompile Include="..\..\..\src\cli\vm.c" />
+    <ClCompile Include="..\..\..\src\module\io.c" />
+    <ClCompile Include="..\..\..\src\module\scheduler.c" />
+    <ClCompile Include="..\..\..\src\module\timer.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\src\include\wren.h" />
+    <ClInclude Include="..\..\..\src\cli\modules.h" />
+    <ClInclude Include="..\..\..\src\cli\vm.h" />
+    <ClInclude Include="..\..\..\src\module\io.h" />
+    <ClInclude Include="..\..\..\src\module\scheduler.h" />
+    <ClInclude Include="..\..\..\src\module\timer.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\wren_lib\wren_lib.vcxproj">
+      <Project>{89cf2c43-749e-4ec4-a7c3-3f22fba9b874}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/util/msvc2013/wren/wren.vcxproj
+++ b/util/msvc2013/wren/wren.vcxproj
@@ -42,14 +42,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)..\..\src\include</IncludePath>
-    <LibraryPath>$(SolutionDir)..\..\build\vs\$(Configuration)\;$(SolutionDir)..\..\util\deps\libuv\Release\lib\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
-    <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
+    <LibraryPath>$(SolutionDir)..\..\lib\$(Configuration)\;$(SolutionDir)..\..\util\deps\libuv\Release\lib\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
+    <OutDir>$(SolutionDir)..\..\bin\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\..\build\cli\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(SolutionDir)..\..\src\include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)..\..\build\vs\$(Configuration)\;$(SolutionDir)..\..\util\deps\libuv\Release\lib\;$(LibraryPath)</LibraryPath>
-    <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
+    <LibraryPath>$(SolutionDir)..\..\lib\$(Configuration)\;$(SolutionDir)..\..\util\deps\libuv\Release\lib\;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)..\..\bin\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\..\build\cli\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/util/msvc2013/wren/wren.vcxproj
+++ b/util/msvc2013/wren/wren.vcxproj
@@ -99,7 +99,6 @@
     <ClInclude Include="..\..\..\src\cli\vm.h" />
     <ClInclude Include="..\..\..\src\module\io.h" />
     <ClInclude Include="..\..\..\src\module\scheduler.h" />
-    <ClInclude Include="..\..\..\src\module\timer.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\wren_lib\wren_lib.vcxproj">

--- a/util/msvc2013/wren/wren.vcxproj.filters
+++ b/util/msvc2013/wren/wren.vcxproj.filters
@@ -50,8 +50,5 @@
     <ClInclude Include="..\..\..\src\module\scheduler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\src\module\timer.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
 </Project>

--- a/util/msvc2013/wren/wren.vcxproj.filters
+++ b/util/msvc2013/wren/wren.vcxproj.filters
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\cli\main.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cli\modules.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\cli\vm.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\module\io.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\module\scheduler.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\module\timer.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\src\include\wren.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\cli\modules.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\cli\vm.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\module\io.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\module\scheduler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\module\timer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/util/msvc2013/wren_lib/wren_lib.vcxproj
+++ b/util/msvc2013/wren_lib/wren_lib.vcxproj
@@ -87,6 +87,7 @@
     <ClCompile Include="..\..\..\src\optional\wren_opt_random.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\src\include\wren.h" />
     <ClInclude Include="..\..\..\src\vm\wren_common.h" />
     <ClInclude Include="..\..\..\src\vm\wren_compiler.h" />
     <ClInclude Include="..\..\..\src\vm\wren_core.h" />

--- a/util/msvc2013/wren_lib/wren_lib.vcxproj
+++ b/util/msvc2013/wren_lib/wren_lib.vcxproj
@@ -39,12 +39,12 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)..\..\src\include;</IncludePath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)..\..\src\include;$(SolutionDir)..\..\src\vm;$(SolutionDir)..\..\src\optional</IncludePath>
     <TargetName>wren_static_d</TargetName>
     <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)..\..\src\include</IncludePath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)..\..\src\include;$(SolutionDir)..\..\src\vm;$(SolutionDir)..\..\src\optional</IncludePath>
     <TargetName>wren_static</TargetName>
     <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
   </PropertyGroup>
@@ -79,24 +79,25 @@
     <ClCompile Include="..\..\..\src\vm\wren_compiler.c" />
     <ClCompile Include="..\..\..\src\vm\wren_core.c" />
     <ClCompile Include="..\..\..\src\vm\wren_debug.c" />
-    <ClCompile Include="..\..\..\src\vm\wren_io.c" />
-    <ClCompile Include="..\..\..\src\vm\wren_meta.c" />
     <ClCompile Include="..\..\..\src\vm\wren_primitive.c" />
     <ClCompile Include="..\..\..\src\vm\wren_utils.c" />
     <ClCompile Include="..\..\..\src\vm\wren_value.c" />
     <ClCompile Include="..\..\..\src\vm\wren_vm.c" />
+    <ClCompile Include="..\..\..\src\optional\wren_opt_meta.c" />
+    <ClCompile Include="..\..\..\src\optional\wren_opt_random.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\vm\wren_common.h" />
     <ClInclude Include="..\..\..\src\vm\wren_compiler.h" />
     <ClInclude Include="..\..\..\src\vm\wren_core.h" />
     <ClInclude Include="..\..\..\src\vm\wren_debug.h" />
-    <ClInclude Include="..\..\..\src\vm\wren_io.h" />
-    <ClInclude Include="..\..\..\src\vm\wren_meta.h" />
     <ClInclude Include="..\..\..\src\vm\wren_primitive.h" />
     <ClInclude Include="..\..\..\src\vm\wren_utils.h" />
     <ClInclude Include="..\..\..\src\vm\wren_value.h" />
+    <ClInclude Include="..\..\..\src\vm\wren_opcodes.h" />
     <ClInclude Include="..\..\..\src\vm\wren_vm.h" />
+    <ClInclude Include="..\..\..\src\optional\wren_opt_meta.h" />
+    <ClInclude Include="..\..\..\src\optional\wren_opt_random.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/util/msvc2013/wren_lib/wren_lib.vcxproj
+++ b/util/msvc2013/wren_lib/wren_lib.vcxproj
@@ -41,12 +41,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)..\..\src\include;$(SolutionDir)..\..\src\vm;$(SolutionDir)..\..\src\optional</IncludePath>
     <TargetName>wren_static_d</TargetName>
-    <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\lib\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\..\build\lib\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)..\..\src\include;$(SolutionDir)..\..\src\vm;$(SolutionDir)..\..\src\optional</IncludePath>
     <TargetName>wren_static</TargetName>
-    <OutDir>$(SolutionDir)..\..\build\vs\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)..\..\lib\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\..\build\lib\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/util/msvc2013/wren_lib/wren_lib.vcxproj.filters
+++ b/util/msvc2013/wren_lib/wren_lib.vcxproj.filters
@@ -24,9 +24,6 @@
     <ClCompile Include="..\..\..\src\vm\wren_debug.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\src\vm\wren_io.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\src\vm\wren_utils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -36,10 +33,13 @@
     <ClCompile Include="..\..\..\src\vm\wren_vm.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\src\vm\wren_meta.c">
+    <ClCompile Include="..\..\..\src\vm\wren_primitive.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\src\vm\wren_primitive.c">
+    <ClCompile Include="..\..\..\src\optional\wren_opt_meta.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\optional\wren_opt_random.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -56,22 +56,25 @@
     <ClInclude Include="..\..\..\src\vm\wren_debug.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\src\vm\wren_io.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\src\vm\wren_utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\vm\wren_value.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\src\vm\wren_opcodes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\src\vm\wren_vm.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\src\vm\wren_meta.h">
+    <ClInclude Include="..\..\..\src\vm\wren_primitive.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\src\vm\wren_primitive.h">
+    <ClInclude Include="..\..\..\src\optional\wren_opt_meta.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\optional\wren_opt_random.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/util/msvc2013/wren_lib/wren_lib.vcxproj.filters
+++ b/util/msvc2013/wren_lib/wren_lib.vcxproj.filters
@@ -44,6 +44,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\src\include\wren.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\src\vm\wren_common.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
The Visual Studio projects were out of sync (and the CLI one was removed!) and this updates them so we can compile in VS again.

There were some issues in the code that I'm not 100% sure how to handle:
* `uv_fs_t::bufs` is accessed directly but that doesn't work in VC++, I have no idea what the proper way to do this in libuv so I just used what compiled
* `S_IRUSR` is not defined on Windows, and I don't know what it would map to. Replaced with 0 for now because I don't think it's used unless `O_CREAT` is given. [This might be useful.](http://stackoverflow.com/a/593017/1056845)
* The macros used in `modules.c` were causing syntax errors because of the nested `{}` in the object initializers. Removing them seems to work but I haven't tested on other compilers, let's see what the CI says about it.