### PR TITLE
Upgrade libuv to 1.8.0

### DIFF
--- a/util/libuv.py
+++ b/util/libuv.py
@@ -11,7 +11,7 @@ import shutil
 import subprocess
 import sys
 
-LIB_UV_VERSION = "v1.6.1"
+LIB_UV_VERSION = "v1.8.0"
 LIB_UV_DIR = "deps/libuv"
 
 def python2_binary():


### PR DESCRIPTION
Might as well upgrade to a newer libuv while it is free to do so. The interesting changes between 1.6.1 includes a bunch of Windows fixes, a new uv_fs_realpath function and proper Android support, among other things.

The more detailed changelog can be seen here: https://github.com/libuv/libuv/compare/v1.6.1...v1.8.0#diff-02f0b547c2779d25cff89672135f20e3