### PR TITLE
Adds callback for error messages

### DIFF
--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -58,6 +58,9 @@ typedef WrenForeignMethodFn (*WrenBindForeignMethodFn)(WrenVM* vm,
 // Displays a string of text to the user.
 typedef void (*WrenWriteFn)(WrenVM* vm, const char* text);
 
+// Displays runtime or compile time error text to the user.
+typedef void (*WrenErrorFn)(WrenVM* vm, const char* text);
+
 typedef struct
 {
   // The callback invoked when the foreign object is created.
@@ -126,6 +129,12 @@ typedef struct
   //
   // If this is `NULL`, Wren discards any printed text.
   WrenWriteFn writeFn;
+
+  // The callback Wren uses to display text when a runtime or compile-time
+  // error has occurred.
+  //
+  // If this is `NULL`, Wren writes the error to stderr.
+  WrenErrorFn errorFn;
 
   // The number of bytes Wren will allocate before triggering the first garbage
   // collection.

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -382,7 +382,7 @@ static void lexError(Parser* parser, const char* format, ...)
   parser->hasError = true;
   if (!parser->printErrors) return;
 
-  fprintf(stderr, "[%s line %d] Error: ",
+  wrenPrintError(parser->vm, "[%s line %d] Error: ",
           parser->module->name->value, parser->currentLine);
 
   va_list args;
@@ -412,7 +412,7 @@ static void error(Compiler* compiler, const char* format, ...)
   // reported it.
   if (token->type == TOKEN_ERROR) return;
 
-  fprintf(stderr, "[%s line %d] Error at ",
+  wrenPrintError(compiler->parser->vm, "[%s line %d] Error at ",
           compiler->parser->module->name->value, token->line);
 
   if (token->type == TOKEN_LINE)

--- a/src/vm/wren_debug.c
+++ b/src/vm/wren_debug.c
@@ -1,18 +1,19 @@
 #include <stdio.h>
 
 #include "wren_debug.h"
+#include "wren_vm.h"
 
-void wrenDebugPrintStackTrace(ObjFiber* fiber)
+void wrenDebugPrintStackTrace(WrenVM* vm, ObjFiber* fiber)
 {
   if (IS_STRING(fiber->error))
   {
-    fprintf(stderr, "%s\n", AS_CSTRING(fiber->error));
+    wrenPrintError(vm, "%s\n", AS_CSTRING(fiber->error));
   }
   else
   {
     // TODO: Print something a little useful here. Maybe the name of the error's
     // class?
-    fprintf(stderr, "[error object]\n");
+    wrenPrintError(vm, "[error object]\n");
   }
 
   for (int i = fiber->numFrames - 1; i >= 0; i--)
@@ -30,7 +31,7 @@ void wrenDebugPrintStackTrace(ObjFiber* fiber)
     
     // -1 because IP has advanced past the instruction that it just executed.
     int line = fn->debug->sourceLines.data[frame->ip - fn->code.data - 1];
-    fprintf(stderr, "[%s line %d] in %s\n",
+    wrenPrintError(vm, "[%s line %d] in %s\n",
             fn->module->name->value, line, fn->debug->name);
   }
 }

--- a/src/vm/wren_debug.h
+++ b/src/vm/wren_debug.h
@@ -7,7 +7,7 @@
 // Prints the current stack trace for [fiber] to stderr.
 //
 // Used when a fiber throws a runtime error which is not caught.
-void wrenDebugPrintStackTrace(ObjFiber* fiber);
+void wrenDebugPrintStackTrace(WrenVM* vm, ObjFiber* fiber);
 
 // The "dump" functions are used for debugging Wren itself. Normal code paths
 // will not call them unless one of the various DEBUG_ flags is enabled.

--- a/src/vm/wren_utils.c
+++ b/src/vm/wren_utils.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "wren_utils.h"
 #include "wren_vm.h"
@@ -197,36 +198,33 @@ void defaultErrorFn(WrenVM* vm, const char* text)
   fprintf(stderr, "%s", text);
 }
 
-// Prints to WrenVM.errorFn if provided, otherwise prints to stderr.
+#if defined( _MSC_VER ) && _MSC_VER < 1900
+// Emulate snprintf() on MSVC<2015, _snprintf() doesn't zero-terminate the buffer
+// on overflow. Adapted from libuv.
+int vsnprintf(char* buf, size_t len, const char* fmt, va_list ap) {
+  int n;
+  n = _vscprintf(fmt, ap);
+  vsnprintf_s(buf, len, _TRUNCATE, fmt, ap);
+  return n;
+}
+#endif
+
+// Prints to WrenVM.config.errorFn if provided, otherwise prints to stderr.
 void wrenPrintError(WrenVM* vm, const char* format, ...)
 {
   va_list args;
   
-#if defined( _MSC_VER ) && _MSC_VER < 1900
-  // MSVC doesn't have snprintf():
-  #define WREN_STRING_SIZE(format, args) _vscprintf(format, args)
-  #define WREN_STRING_PRINT(buffer, size, format, args) _vsnprintf_s(buffer, size, _TRUNCATE, format, args)
-#else
-  // Use C99's snprintf():
-  #define WREN_STRING_SIZE(format, args) vsnprintf(NULL, 0, format, args)
-  #define WREN_STRING_PRINT(buffer, size, format, args) vsnprintf(buffer, size, format, args)
-#endif
-
   // Allocate `buffer` to hold the output:
   va_start(args, format);
-  int sizeNeeded = WREN_STRING_SIZE(format, args);
+  int sizeNeeded = vsnprintf(NULL, 0, format, args);
   int sizeAllocated = sizeNeeded + 1; // +1 for the null terminator
   char *buffer = (char *)vm->config.reallocateFn(NULL, sizeAllocated);
   va_end(args);
   
-
   // Write the format and args into `buffer`:
   va_start(args, format);
-  WREN_STRING_PRINT(buffer, sizeAllocated, format, args);
+  vsnprintf(buffer, sizeAllocated, format, args);
   va_end(args);
-  
-  #undef WREN_STRING_SIZE
-  #undef WREN_STRING_PRINT
   
   // Output `buffer`:
   vm->config.errorFn(vm, buffer);

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1642,7 +1642,7 @@ void wrenPrintError(WrenVM* vm, const char* format, ...)
   va_start(args, format);
   int sizeNeeded = WREN_STRING_SIZE(format, args);
   int sizeAllocated = sizeNeeded + 1; // +1 for the null terminator
-  char *buffer = malloc(sizeAllocated);
+  char *buffer = (char *)malloc(sizeAllocated);
   va_end(args);
 
   // Write the format and args into `buffer`:

--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -125,6 +125,10 @@ struct WrenVM
 //   [oldSize] will be zero. It should return NULL.
 void* wrenReallocate(WrenVM* vm, void* memory, size_t oldSize, size_t newSize);
 
+// Prints an error to the configuration's `errorFn`, if non-NULL.
+// Otherwise, prints to stderr.
+void wrenPrintError(WrenVM* vm, const char* format, ...);
+
 // Invoke the finalizer for the foreign object referenced by [foreign].
 void wrenFinalizeForeign(WrenVM* vm, ObjForeign* foreign);
 


### PR DESCRIPTION
For #265, adds `WrenConfiguration.errorFn`, similar to `writeFn`, which gives embedders access to parse/compile/runtime error messages.

Only caveat is that I haven't been able to test the MSVC code; it was taken from a post that @munificent [linked](https://social.msdn.microsoft.com/Forums/vstudio/en-US/2b339bdf-7ab1-4a08-bf7e-e9293801455b/c99-standard-snprintf-function-?forum=vcgeneral).

Room for improvement: this should be added to the API tests, but haven't had time to figure that area out.

A big hat tip to @ppvk for bringing some activity back to this issue!