### PR TITLE
Allow builds to be verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,73 +2,79 @@
 # compile Wren itself, it invokes util/wren.mk for the various configurations
 # that Wren can be built with.
 
+# Allows one to enable verbose builds with VERBOSE=1
+V := @
+ifeq ($(VERBOSE),1)
+	V :=
+endif
+
 # Executables are built to bin/. Libraries are built to lib/.
 
 # A normal, optimized release build for the current CPU architecture.
 release:
-	@ $(MAKE) -f util/wren.mk
-	@ cp bin/wren wren # For convenience, copy the interpreter to the top level.
+	$(V) $(MAKE) -f util/wren.mk
+	$(V) cp bin/wren wren # For convenience, copy the interpreter to the top level.
 
 # A debug build for the current architecture.
 debug:
-	@ $(MAKE) -f util/wren.mk MODE=debug
+	$(V) $(MAKE) -f util/wren.mk MODE=debug
 
 # A release build of just the VM, both shared and static libraries.
 vm:
-	@ $(MAKE) -f util/wren.mk vm
+	$(V) $(MAKE) -f util/wren.mk vm
 
 # A release build of the shared library for the VM.
 shared:
-	@ $(MAKE) -f util/wren.mk shared
+	$(V) $(MAKE) -f util/wren.mk shared
 
 # A release build of the shared library for the VM.
 static:
-	@ $(MAKE) -f util/wren.mk static
+	$(V) $(MAKE) -f util/wren.mk static
 
 # Build all configurations.
 all: debug release
-	@ $(MAKE) -f util/wren.mk LANG=cpp
-	@ $(MAKE) -f util/wren.mk MODE=debug LANG=cpp
-	@ $(MAKE) -f util/wren.mk ARCH=32
-	@ $(MAKE) -f util/wren.mk LANG=cpp ARCH=32
-	@ $(MAKE) -f util/wren.mk MODE=debug ARCH=32
-	@ $(MAKE) -f util/wren.mk MODE=debug LANG=cpp ARCH=32
-	@ $(MAKE) -f util/wren.mk ARCH=64
-	@ $(MAKE) -f util/wren.mk LANG=cpp ARCH=64
-	@ $(MAKE) -f util/wren.mk MODE=debug ARCH=64
-	@ $(MAKE) -f util/wren.mk MODE=debug LANG=cpp ARCH=64
+	$(V) $(MAKE) -f util/wren.mk LANG=cpp
+	$(V) $(MAKE) -f util/wren.mk MODE=debug LANG=cpp
+	$(V) $(MAKE) -f util/wren.mk ARCH=32
+	$(V) $(MAKE) -f util/wren.mk LANG=cpp ARCH=32
+	$(V) $(MAKE) -f util/wren.mk MODE=debug ARCH=32
+	$(V) $(MAKE) -f util/wren.mk MODE=debug LANG=cpp ARCH=32
+	$(V) $(MAKE) -f util/wren.mk ARCH=64
+	$(V) $(MAKE) -f util/wren.mk LANG=cpp ARCH=64
+	$(V) $(MAKE) -f util/wren.mk MODE=debug ARCH=64
+	$(V) $(MAKE) -f util/wren.mk MODE=debug LANG=cpp ARCH=64
 
 # Remove all build outputs and intermediate files. Does not remove downloaded
 # dependencies. Use cleanall for that.
 clean:
-	@ rm -rf bin
-	@ rm -rf build
-	@ rm -rf lib
+	$(V) rm -rf bin
+	$(V) rm -rf build
+	$(V) rm -rf lib
 
 # Remove all build outputs, intermediate files, and downloaded dependencies.
 cleanall: clean
-	@ rm -rf deps
+	$(V) rm -rf deps
 
 # Run the tests against the debug build of Wren.
 test: debug
-	@ $(MAKE) -f util/wren.mk MODE=debug test
-	@ ./util/test.py $(suite)
+	$(V) $(MAKE) -f util/wren.mk MODE=debug test
+	$(V) ./util/test.py $(suite)
 
 benchmark: release
-	@ $(MAKE) -f util/wren.mk test
-	@ ./util/benchmark.py -l wren $(suite)
+	$(V) $(MAKE) -f util/wren.mk test
+	$(V) ./util/benchmark.py -l wren $(suite)
 
 # Generate the Wren site.
 docs:
-	@ ./util/generate_docs.py
+	$(V) ./util/generate_docs.py
 
 # Continuously generate the Wren site.
 watchdocs:
-	@ ./util/generate_docs.py --watch
+	$(V) ./util/generate_docs.py --watch
 
 # Build the docs and copy them to a local "gh-pages" directory.
 gh-pages: docs
-	@ cp -r build/docs/. build/gh-pages
+	$(V) cp -r build/docs/. build/gh-pages
 
 # Build amalgamation of all Wren library files.
 amalgamation: src/include/wren.h src/vm/*.h src/vm/*.c

--- a/util/wren.mk
+++ b/util/wren.mk
@@ -36,6 +36,12 @@ TEST_SOURCES := $(wildcard test/api/*.c)
 
 BUILD_DIR := build
 
+# Allows one to enable verbose builds with VERBOSE=1
+V := @
+ifeq ($(VERBOSE),1)
+	V :=
+endif
+
 C_WARNINGS := -Wall -Wextra -Werror -Wno-unused-parameter
 # Wren uses callbacks heavily, so -Wunused-parameter is too painful to enable.
 
@@ -151,80 +157,80 @@ test: $(BUILD_DIR)/test/$(WREN)
 bin/$(WREN): $(OPT_OBJECTS) $(CLI_OBJECTS) $(MODULE_OBJECTS) $(VM_OBJECTS) \
 		$(LIBUV)
 	@ printf "%10s %-30s %s\n" $(CC) $@ "$(C_OPTIONS)"
-	@ mkdir -p bin
-	@ $(CC) $(CFLAGS) $^ -o $@ -lm $(LIBUV_LIBS)
+	$(V) mkdir -p bin
+	$(V) $(CC) $(CFLAGS) $^ -o $@ -lm $(LIBUV_LIBS)
 
 # Static library.
 lib/lib$(WREN).a: $(OPT_OBJECTS) $(VM_OBJECTS)
 	@ printf "%10s %-30s %s\n" $(AR) $@ "rcu"
-	@ mkdir -p lib
-	@ $(AR) rcu $@ $^
+	$(V) mkdir -p lib
+	$(V) $(AR) rcu $@ $^
 
 # Shared library.
 lib/lib$(WREN).$(SHARED_EXT): $(OPT_OBJECTS) $(VM_OBJECTS)
 	@ printf "%10s %-30s %s\n" $(CC) $@ "$(C_OPTIONS) $(SHARED_LIB_FLAGS)"
-	@ mkdir -p lib
-	@ $(CC) $(CFLAGS) -shared $(SHARED_LIB_FLAGS) -o $@ $^
+	$(V) mkdir -p lib
+	$(V) $(CC) $(CFLAGS) -shared $(SHARED_LIB_FLAGS) -o $@ $^
 
 # Test executable.
 $(BUILD_DIR)/test/$(WREN): $(OPT_OBJECTS) $(MODULE_OBJECTS) $(TEST_OBJECTS) \
 		$(VM_OBJECTS) $(BUILD_DIR)/cli/modules.o $(BUILD_DIR)/cli/vm.o $(LIBUV)
 	@ printf "%10s %-30s %s\n" $(CC) $@ "$(C_OPTIONS)"
-	@ mkdir -p $(BUILD_DIR)/test
-	@ $(CC) $(CFLAGS) $^ -o $@ -lm $(LIBUV_LIBS)
+	$(V) mkdir -p $(BUILD_DIR)/test
+	$(V) $(CC) $(CFLAGS) $^ -o $@ -lm $(LIBUV_LIBS)
 
 # CLI object files.
 $(BUILD_DIR)/cli/%.o: src/cli/%.c $(CLI_HEADERS) $(MODULE_HEADERS) \
 		$(VM_HEADERS) $(LIBUV)
 	@ printf "%10s %-30s %s\n" $(CC) $< "$(C_OPTIONS)"
-	@ mkdir -p $(BUILD_DIR)/cli
-	@ $(CC) -c $(CFLAGS) $(CLI_FLAGS) -o $@ $(FILE_FLAG) $<
+	$(V) mkdir -p $(BUILD_DIR)/cli
+	$(V) $(CC) -c $(CFLAGS) $(CLI_FLAGS) -o $@ $(FILE_FLAG) $<
 
 # Module object files.
 $(BUILD_DIR)/module/%.o: src/module/%.c $(CLI_HEADERS) $(MODULE_HEADERS) \
 		$(VM_HEADERS) $(LIBUV)
 	@ printf "%10s %-30s %s\n" $(CC) $< "$(C_OPTIONS)"
-	@ mkdir -p $(BUILD_DIR)/module
-	@ $(CC) -c $(CFLAGS) $(CLI_FLAGS) -o $@ $(FILE_FLAG) $<
+	$(V) mkdir -p $(BUILD_DIR)/module
+	$(V) $(CC) -c $(CFLAGS) $(CLI_FLAGS) -o $@ $(FILE_FLAG) $<
 
 # Aux object files.
 $(BUILD_DIR)/optional/%.o: src/optional/%.c $(VM_HEADERS) $(OPT_HEADERS)
 	@ printf "%10s %-30s %s\n" $(CC) $< "$(C_OPTIONS)"
-	@ mkdir -p $(BUILD_DIR)/optional
-	@ $(CC) -c $(CFLAGS) -Isrc/include -Isrc/vm -o $@ $(FILE_FLAG) $<
+	$(V) mkdir -p $(BUILD_DIR)/optional
+	$(V) $(CC) -c $(CFLAGS) -Isrc/include -Isrc/vm -o $@ $(FILE_FLAG) $<
 
 # VM object files.
 $(BUILD_DIR)/vm/%.o: src/vm/%.c $(VM_HEADERS)
 	@ printf "%10s %-30s %s\n" $(CC) $< "$(C_OPTIONS)"
-	@ mkdir -p $(BUILD_DIR)/vm
-	@ $(CC) -c $(CFLAGS) -Isrc/include -Isrc/optional -Isrc/vm -o $@ $(FILE_FLAG) $<
+	$(V) mkdir -p $(BUILD_DIR)/vm
+	$(V) $(CC) -c $(CFLAGS) -Isrc/include -Isrc/optional -Isrc/vm -o $@ $(FILE_FLAG) $<
 
 # Test object files.
 $(BUILD_DIR)/test/%.o: test/api/%.c $(OPT_HEADERS) $(MODULE_HEADERS) \
 		 $(VM_HEADERS) $(TEST_HEADERS) $(LIBUV)
 	@ printf "%10s %-30s %s\n" $(CC) $< "$(C_OPTIONS)"
-	@ mkdir -p $(dir $@)
-	@ $(CC) -c $(CFLAGS) $(CLI_FLAGS) -o $@ $(FILE_FLAG) $<
+	$(V) mkdir -p $(dir $@)
+	$(V) $(CC) -c $(CFLAGS) $(CLI_FLAGS) -o $@ $(FILE_FLAG) $<
 
 # Download libuv.
 $(LIBUV_DIR)/build/gyp/gyp: util/libuv.py
-	@ ./util/libuv.py download
+	$(V) ./util/libuv.py download
 
 # Build libuv to a static library.
 $(LIBUV): $(LIBUV_DIR)/build/gyp/gyp util/libuv.py
-	@ ./util/libuv.py build $(LIBUV_ARCH)
+	$(V) ./util/libuv.py build $(LIBUV_ARCH)
 
 # Wren modules that get compiled into the binary as C strings.
 src/optional/wren_opt_%.wren.inc: src/optional/wren_opt_%.wren util/wren_to_c_string.py
 	@ printf "%10s %-30s %s\n" str $<
-	@ ./util/wren_to_c_string.py $@ $<
+	$(V) ./util/wren_to_c_string.py $@ $<
 
 src/vm/wren_%.wren.inc: src/vm/wren_%.wren util/wren_to_c_string.py
 	@ printf "%10s %-30s %s\n" str $<
-	@ ./util/wren_to_c_string.py $@ $<
+	$(V) ./util/wren_to_c_string.py $@ $<
 
 src/module/%.wren.inc: src/module/%.wren util/wren_to_c_string.py
 	@ printf "%10s %-30s %s\n" str $<
-	@ ./util/wren_to_c_string.py $@ $<
+	$(V) ./util/wren_to_c_string.py $@ $<
 
 .PHONY: all cli test vm


### PR DESCRIPTION
It’s impossible to disable `@`s in Makefiles to get a verbose build. Adding them conditionally lets users choose if they want a verbose build by using the `VERBOSE` variable.

Normal build:

    make

Verbose build:

    make VERBOSE=1

I stole this idea from [this SO thread](http://stackoverflow.com/q/3861911/735926). Note we could also remove both the variable, the `printf`s and the `@`s and get a verbose build by default.