### PR TITLE
missed bytecode name refactoring

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -742,7 +742,7 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
         do                                                        \
         {                                                         \
           wrenDumpStack(fiber);                                   \
-          wrenDumpInstruction(vm, fn, (int)(ip - fn->bytecode));  \
+          wrenDumpInstruction(vm, fn, (int)(ip - fn->code.data)); \
         }                                                         \
         while (false)
   #else


### PR DESCRIPTION
A missed "rename". Visible only when WREN_DEBUG_TRACE_INSTRUCTIONS is 1.