### PR TITLE
Implement String indexOf(needle, startIndex)

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -869,7 +869,7 @@ DEF_PRIMITIVE(string_contains)
   ObjString* string = AS_STRING(args[0]);
   ObjString* search = AS_STRING(args[1]);
 
-  RETURN_BOOL(wrenStringFind(string, search) != UINT32_MAX);
+  RETURN_BOOL(wrenStringFind(string, search, 0) != UINT32_MAX);
 }
 
 DEF_PRIMITIVE(string_endsWith)
@@ -893,7 +893,19 @@ DEF_PRIMITIVE(string_indexOf)
   ObjString* string = AS_STRING(args[0]);
   ObjString* search = AS_STRING(args[1]);
 
-  uint32_t index = wrenStringFind(string, search);
+  uint32_t index = wrenStringFind(string, search, 0);
+  RETURN_NUM(index == UINT32_MAX ? -1 : (int)index);
+}
+
+DEF_PRIMITIVE(string_indexOf_with_startIndex)
+{
+  if (!validateString(vm, args[1], "Argument")) return false;
+
+  ObjString* string = AS_STRING(args[0]);
+  ObjString* search = AS_STRING(args[1]);
+  uint32_t startIndex = AS_NUM(args[2]);
+
+  uint32_t index = wrenStringFind(string, search, startIndex);
   RETURN_NUM(index == UINT32_MAX ? -1 : (int)index);
 }
 
@@ -1252,6 +1264,7 @@ void wrenInitializeCore(WrenVM* vm)
   PRIMITIVE(vm->stringClass, "contains(_)", string_contains);
   PRIMITIVE(vm->stringClass, "endsWith(_)", string_endsWith);
   PRIMITIVE(vm->stringClass, "indexOf(_)", string_indexOf);
+  PRIMITIVE(vm->stringClass, "indexOf(_,_)", string_indexOf_with_startIndex);
   PRIMITIVE(vm->stringClass, "iterate(_)", string_iterate);
   PRIMITIVE(vm->stringClass, "iterateByte_(_)", string_iterateByte);
   PRIMITIVE(vm->stringClass, "iteratorValue(_)", string_iteratorValue);

--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -854,13 +854,16 @@ Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, uint32_t index)
 }
 
 // Uses the Boyer-Moore-Horspool string matching algorithm.
-uint32_t wrenStringFind(ObjString* haystack, ObjString* needle)
+uint32_t wrenStringFind(ObjString* haystack, ObjString* needle, uint32_t startIndex)
 {
   // Corner case, an empty needle is always found.
   if (needle->length == 0) return 0;
 
   // If the needle is longer than the haystack it won't be found.
-  if (needle->length > haystack->length) return UINT32_MAX;
+  if (needle->length > (haystack->length - startIndex)) return UINT32_MAX;
+
+  // If the startIndex is too far it also won't be found.
+  if (startIndex >= haystack->length) return UINT32_MAX;
 
   // Pre-calculate the shift table. For each character (8-bit value), we
   // determine how far the search window can be advanced if that character is
@@ -890,18 +893,18 @@ uint32_t wrenStringFind(ObjString* haystack, ObjString* needle)
   // Slide the needle across the haystack, looking for the first match or
   // stopping if the needle goes off the end.
   char lastChar = needle->value[needleEnd];
-  uint32_t range = haystack->length - needle->length;
+  uint32_t range = (haystack->length - startIndex) - needle->length;
 
   for (uint32_t index = 0; index <= range; )
   {
     // Compare the last character in the haystack's window to the last character
     // in the needle. If it matches, see if the whole needle matches.
-    char c = haystack->value[index + needleEnd];
+    char c = haystack->value[startIndex + (index + needleEnd)];
     if (lastChar == c &&
-        memcmp(haystack->value + index, needle->value, needleEnd) == 0)
+        memcmp(haystack->value + startIndex + index, needle->value, needleEnd) == 0)
     {
       // Found a match.
-      return index;
+      return index + startIndex;
     }
 
     // Otherwise, slide the needle forward.

--- a/src/vm/wren_value.h
+++ b/src/vm/wren_value.h
@@ -728,7 +728,7 @@ Value wrenStringCodePointAt(WrenVM* vm, ObjString* string, uint32_t index);
 // Search for the first occurence of [needle] within [haystack] and returns its
 // zero-based offset. Returns `UINT32_MAX` if [haystack] does not contain
 // [needle].
-uint32_t wrenStringFind(ObjString* haystack, ObjString* needle);
+uint32_t wrenStringFind(ObjString* haystack, ObjString* needle, uint32_t startIndex);
 
 // Creates a new open upvalue pointing to [value] on the stack.
 ObjUpvalue* wrenNewUpvalue(WrenVM* vm, Value* value);

--- a/test/core/string/index_of.wren
+++ b/test/core/string/index_of.wren
@@ -5,6 +5,12 @@ System.print("abcd".indexOf("abcd")) // expect: 0
 System.print("abcd".indexOf("abcde")) // expect: -1
 System.print("abab".indexOf("ab")) // expect: 0
 
+System.print("abcd".indexOf("cd", 0)) // expect: 2
+System.print("abcd".indexOf("cd", 1)) // expect: 2
+System.print("abcd".indexOf("cd", 2)) // expect: 2
+System.print("abcd".indexOf("cd", 3)) // expect: -1
+System.print("abcd".indexOf("cd", 10)) // expect: -1
+
 // More complex cases.
 System.print("abcdefabcdefg".indexOf("defg")) // expect: 9
 System.print("abcdabcdabcd".indexOf("dab")) // expect: 3


### PR DESCRIPTION
The ability to offset the search inside the string is critical for many string operations.
A good example is a string split (or replace) method (implemented in wren, not in core). 
Without the ability to consume the string without a copy, the alternative is to duplicate 
the remaining part, generating both new ranges and new strings. This is bad for garbage, 
and on larger strings like data files can get prohibitively expensive.

In my case, parsing/splitting a dense 92KB file (19582 lines) with several thousand split calls, by line, and then by token per line, dropped from ~750ms down to 14ms running time alone (for newlines, for further parsing it was around 70ms on top which didn't change much as the lines being split weren't as long).

I added some basic tests, and ran the benchmarks before and after (see below).

**Notes**
There are some things that I think could be improved in the implemenation detail later.

For example, it might be nice (and consistent) to have startIndex allow negative values, which would behave like ranges do and use the end as a marker. I also tried to keep the code as similar to what it was at first to make sure the differences are clear.

Feedback welcome!

Things I wasn't sure of specifically:
- The `..indexOf_with_startIndex` naming
- Whether or not it should be a separate function, or handled inside existing `indexOf` with arg checks. If so, how to query for unspecified args? IS_NULL returned false for those...

**benchmark** 

```
api_call - wren                .......... 0.10s 0.0028 101.67% relative to baseline
api_foreign_method - wren      .......... 0.45s 0.0097 100.73% relative to baseline
binary_trees - wren            .......... 0.36s 0.0060 100.34% relative to baseline
binary_trees_gc - wren         .......... 1.14s 0.0085 101.32% relative to baseline
delta_blue - wren              .......... 0.27s 0.0027 100.93% relative to baseline
fib - wren                     .......... 0.32s 0.0047  97.67% relative to baseline
fibers - wren                  .......... 0.06s 0.0022  99.09% relative to baseline
for - wren                     .......... 0.11s 0.0022 100.56% relative to baseline
method_call - wren             .......... 0.22s 0.0043 104.13% relative to baseline
map_numeric - wren             .......... 0.37s 0.0034 100.27% relative to baseline
map_string - wren              .......... 0.15s 0.0016  99.58% relative to baseline
string_equals - wren           .......... 0.30s 0.0074 103.72% relative to baseline
```