### PR TITLE
Implement basic sandbox functionality

### DIFF
--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -206,6 +206,12 @@ typedef struct
   //
   // If zero, defaults to 50.
   int heapGrowthPercent;
+
+#if WREN_SANDBOX
+  int64_t maxRunOps;
+  int64_t maxHeapSize;
+#endif
+
 } WrenConfiguration;
 
 typedef enum

--- a/src/vm/wren_common.h
+++ b/src/vm/wren_common.h
@@ -48,11 +48,27 @@
 // these or not. By default, they are all available. To disable one, set the
 // corresponding `WREN_OPT_<name>` define to `0`.
 #ifndef WREN_OPT_META
-  #define WREN_OPT_META 1
+  #define WREN_OPT_META 0
 #endif
 
 #ifndef WREN_OPT_RANDOM
-  #define WREN_OPT_RANDOM 1
+  #define WREN_OPT_RANDOM 0
+#endif
+
+// If true, the VM's interpreter loop will keep track of how many operations
+// have been executed and abort with a runtime error when the limit is exceeded.
+// The sandbox is unable to defend against native calls entering an infinite loop.
+#ifndef WREN_SANDBOX
+  #define WREN_SANDBOX 0
+#endif
+#if WREN_SANDBOX
+
+#ifndef WREN_DEFAULT_MAX_RUN_OPS
+   #define WREN_DEFAULT_MAX_RUN_OPS (((int64_t)1) << 62)
+ #endif
+ #ifndef WREN_DEFAULT_MAX_HEAP_SIZE
+   #define WREN_DEFAULT_MAX_HEAP_SIZE  (1024*1024*128) // 64 MB
+ #endif
 #endif
 
 // These flags are useful for debugging and hacking on Wren itself. They are not

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -46,6 +46,11 @@ void wrenInitConfiguration(WrenConfiguration* config)
   config->initialHeapSize = 1024 * 1024 * 10;
   config->minHeapSize = 1024 * 1024;
   config->heapGrowthPercent = 50;
+
+#if WREN_SANDBOX
+  config->maxRunOps = WREN_DEFAULT_MAX_RUN_OPS;
+  config->maxHeapSize  = WREN_DEFAULT_MAX_HEAP_SIZE;
+#endif
 }
 
 WrenVM* wrenNewVM(WrenConfiguration* config)
@@ -72,6 +77,9 @@ WrenVM* wrenNewVM(WrenConfiguration* config)
   vm->grayCapacity = 4;
   vm->gray = (Obj**)reallocate(NULL, vm->grayCapacity * sizeof(Obj*));
   vm->nextGC = vm->config.initialHeapSize;
+#if WREN_SANDBOX
+  vm->totalRunOps = vm->config.maxRunOps;
+#endif
 
   wrenSymbolTableInit(&vm->methodNames);
 
@@ -213,6 +221,13 @@ void* wrenReallocate(WrenVM* vm, void* memory, size_t oldSize, size_t newSize)
   if (newSize > 0) wrenCollectGarbage(vm);
 #else
   if (newSize > 0 && vm->bytesAllocated > vm->nextGC) wrenCollectGarbage(vm);
+#endif
+
+#if WREN_SANDBOX
+  if( vm->bytesAllocated > vm->config.maxHeapSize ) {
+     vm->fiber->error = wrenStringFormat(vm, "out of memory" );
+     return 0;
+  }
 #endif
 
   return vm->config.reallocateFn(memory, newSize);
@@ -722,6 +737,30 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
       ip = frame->ip;                                  \
       fn = frame->closure->fn;
 
+
+#if WREN_SANDBOX
+  int64_t op_count = vm->totalRunOps;
+
+  #define STORE_RUN_OPS() vm->totalRunOps = op_count
+
+     /**
+      *  Cannot call RUNTIME_ERROR because RUNTIME_ERROR calls DISPATCH
+      *  which calls CHECK_OP_COUNT
+      */
+     #define CHECK_OP_COUNT()                                           \
+         do {                                                           \
+           if( --op_count <= 0 ) {                                      \
+              vm->totalRunOps = 0;                                      \
+              STORE_FRAME();                                            \
+              runtimeError(vm);                                         \
+              return WREN_RESULT_RUNTIME_ERROR;                         \
+           }                                                            \
+         } while ( false )
+#else
+     #define CHECK_OP_COUNT() do { } while (false)
+     #define STORE_RUN_OPS() do { } while (false)
+#endif // WREN_SANDBOX
+
   // Terminates the current fiber with error string [error]. If another calling
   // fiber is willing to catch the error, transfers control to it, otherwise
   // exits the interpreter.
@@ -730,12 +769,18 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
       {                                                           \
         STORE_FRAME();                                            \
         runtimeError(vm);                                         \
-        if (vm->fiber == NULL) return WREN_RESULT_RUNTIME_ERROR;  \
+        if (vm->fiber == NULL) {                                  \
+           STORE_RUN_OPS();                                       \
+           return WREN_RESULT_RUNTIME_ERROR;                      \
+        }                                                         \
         fiber = vm->fiber;                                        \
         LOAD_FRAME();                                             \
         DISPATCH();                                               \
       }                                                           \
       while (false)
+
+
+
 
   #if WREN_DEBUG_TRACE_INSTRUCTIONS
     // Prints the stack and instruction before each instruction is executed.
@@ -765,6 +810,7 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
       do                                                        \
       {                                                         \
         DEBUG_TRACE_INSTRUCTIONS();                             \
+        CHECK_OP_COUNT();                                       \
         goto *dispatchTable[instruction = (Code)READ_BYTE()];   \
       }                                                         \
       while (false)
@@ -774,6 +820,7 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
   #define INTERPRET_LOOP                                        \
       loop:                                                     \
         DEBUG_TRACE_INSTRUCTIONS();                             \
+        CHECK_OP_COUNT();                                       \
         switch (instruction = (Code)READ_BYTE())
 
   #define CASE_CODE(name)  case CODE_##name
@@ -920,7 +967,10 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
 
             // If we don't have a fiber to switch to, stop interpreting.
             fiber = vm->fiber;
-            if (fiber == NULL) return WREN_RESULT_SUCCESS;
+            if (fiber == NULL) {
+               STORE_RUN_OPS();
+               return WREN_RESULT_SUCCESS;
+            }
             if (!IS_NULL(fiber->error)) RUNTIME_ERROR();
             LOAD_FRAME();
           }
@@ -1091,6 +1141,9 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
           // C API can get it.
           fiber->stack[0] = result;
           fiber->stackTop = fiber->stack + 1;
+
+          STORE_RUN_OPS();
+
           return WREN_RESULT_SUCCESS;
         }
         

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -381,6 +381,7 @@ static void bindMethod(WrenVM* vm, int methodType, int symbol,
 static void callForeign(WrenVM* vm, ObjFiber* fiber,
                         WrenForeignMethodFn foreign, int numArgs)
 {
+  Value* oldApiStack = vm->apiStack; /// save the current state so we can restore it when done
   vm->apiStack = fiber->stackTop - numArgs;
 
   foreign(vm);
@@ -388,7 +389,7 @@ static void callForeign(WrenVM* vm, ObjFiber* fiber,
   // Discard the stack slots for the arguments and temporaries but leave one
   // for the result.
   fiber->stackTop = vm->apiStack + 1;
-  vm->apiStack = NULL;
+  vm->apiStack = oldApiStack; /// restore apiStack to value prior to calling foreign method
 }
 
 // Handles the current fiber having aborted because of an error. Switches to
@@ -670,11 +671,12 @@ static void createForeign(WrenVM* vm, ObjFiber* fiber, Value* stack)
   ASSERT(method->type == METHOD_FOREIGN, "Allocator should be foreign.");
 
   // Pass the constructor arguments to the allocator as well.
+  Value* oldApiStack = vm->apiStack;
   vm->apiStack = stack;
 
   method->fn.foreign(vm);
 
-  vm->apiStack = NULL;
+  vm->apiStack = oldApiStack;
   // TODO: Check that allocateForeign was called.
 }
 

--- a/src/vm/wren_vm.h
+++ b/src/vm/wren_vm.h
@@ -61,6 +61,10 @@ struct WrenVM
   // The number of total allocated bytes that will trigger the next GC.
   size_t nextGC;
 
+#if WREN_SANDBOX
+  size_t totalRunOps;
+#endif
+
   // The first object in the linked list of all currently allocated objects.
   Obj* first;
 


### PR DESCRIPTION
When WREN_SANDBOX is defined the VM can be configured to limit the
number of ops that could be executed before the VM returns a runtime
error.
