### PR TITLE
User data associated with a WrenVM

### DIFF
--- a/src/cli/vm.c
+++ b/src/cli/vm.c
@@ -155,7 +155,7 @@ static void write(WrenVM* vm, const char* text)
 }
 
 static void reportError(WrenErrorType type,
-                        const char* module, int line, const char* message)
+                        const char* module, int line, const char* message, WrenVM* vm)
 {
   switch (type)
   {

--- a/src/include/wren.h
+++ b/src/include/wren.h
@@ -96,7 +96,7 @@ typedef enum
 // Each of those has the module and line where the method or function is
 // defined and [message] is the name of the method or function.
 typedef void (*WrenErrorFn)(
-    WrenErrorType type, const char* module, int line, const char* message);
+    WrenErrorType type, const char* module, int line, const char* message, WrenVM* vm);
 
 typedef struct
 {
@@ -206,6 +206,10 @@ typedef struct
   //
   // If zero, defaults to 50.
   int heapGrowthPercent;
+
+  // User defined state data associated with the WrenVM.
+  void* userData;
+
 } WrenConfiguration;
 
 typedef enum
@@ -446,5 +450,11 @@ void wrenGetVariable(WrenVM* vm, const char* module, const char* name,
 // Sets the current fiber to be aborted, and uses the value in [slot] as the
 // runtime error object.
 void wrenAbortFiber(WrenVM* vm, int slot);
+
+// Returns the user data associated with the WrenVM.
+void* wrenGetUserData(WrenVM* vm);
+
+// Sets user data associated with the WrenVM.
+void wrenSetUserData(WrenVM* vm, void* userData);
 
 #endif

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -404,7 +404,7 @@ static void printError(Parser* parser, int line, const char* label,
   ASSERT(length < ERROR_MESSAGE_SIZE, "Error should not exceed buffer.");
   
   parser->vm->config.errorFn(WREN_ERROR_COMPILE,
-                             parser->module->name->value, line, message);
+                             parser->module->name->value, line, message, parser->vm);
 }
 
 // Outputs a compile or syntax error. This also marks the compilation as having

--- a/src/vm/wren_debug.c
+++ b/src/vm/wren_debug.c
@@ -10,13 +10,13 @@ void wrenDebugPrintStackTrace(WrenVM* vm)
   ObjFiber* fiber = vm->fiber;
   if (IS_STRING(fiber->error))
   {
-    vm->config.errorFn(WREN_ERROR_RUNTIME, NULL, -1, AS_CSTRING(fiber->error));
+    vm->config.errorFn(WREN_ERROR_RUNTIME, NULL, -1, AS_CSTRING(fiber->error), vm);
   }
   else
   {
     // TODO: Print something a little useful here. Maybe the name of the error's
     // class?
-    vm->config.errorFn(WREN_ERROR_RUNTIME, NULL, -1, "[error object]");
+    vm->config.errorFn(WREN_ERROR_RUNTIME, NULL, -1, "[error object]", vm);
   }
 
   for (int i = fiber->numFrames - 1; i >= 0; i--)
@@ -35,7 +35,7 @@ void wrenDebugPrintStackTrace(WrenVM* vm)
     // -1 because IP has advanced past the instruction that it just executed.
     int line = fn->debug->sourceLines.data[frame->ip - fn->code.data - 1];
     vm->config.errorFn(WREN_ERROR_STACK_TRACE, fn->module->name->value, line,
-                       fn->debug->name);
+                       fn->debug->name, vm);
   }
 }
 

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -46,6 +46,7 @@ void wrenInitConfiguration(WrenConfiguration* config)
   config->initialHeapSize = 1024 * 1024 * 10;
   config->minHeapSize = 1024 * 1024;
   config->heapGrowthPercent = 50;
+  config->userData = NULL;
 }
 
 WrenVM* wrenNewVM(WrenConfiguration* config)
@@ -1691,4 +1692,14 @@ void wrenAbortFiber(WrenVM* vm, int slot)
 {
   validateApiSlot(vm, slot);
   vm->fiber->error = vm->apiStack[slot];
+}
+
+void* wrenGetUserData(WrenVM* vm)
+{
+	return vm->config.userData;
+}
+
+void wrenSetUserData(WrenVM* vm, void* userData)
+{
+	vm->config.userData = userData;
 }


### PR DESCRIPTION
I use Wren embedded with C++.  I needed a way to associate a C++ object with each VM so I can have state access during callbacks.

**New API functions**
`void wrenSetUserData(WrenVM* vm, void* userData);`
`void* wrenGetUserData(WrenVM* vm);`

You can also set the user data during VM initialization via the `WrenConfiguration` struct:
`config.userData = this;`

**Breaking API changes**
Added additional vm parameter to `WrenErrorFn` (The only callback that did not specify the VM).
`typedef void (*WrenErrorFn)(
    WrenErrorType type, const char* module, int line, const char* message, WrenVM* vm);`