### PR TITLE
Add split and replace for strings.

### DIFF
--- a/doc/site/modules/core/string.markdown
+++ b/doc/site/modules/core/string.markdown
@@ -129,6 +129,24 @@ negative to count backwards from the end of the string.
 It is a runtime error if `search` is not a string or `start` is not an integer
 index within the string's byte length.
 
+### **split**(seperator)
+
+Returns a list of one or more strings seperated by `seperator`.
+
+    :::wren
+    var string = "abc abc abc"
+    System.print(string.split(" ")) //> [abc, abc, abc]
+
+It is a runtime error if `seperator` is not a string or is an empty string.
+
+### **replace**(old, swap)
+
+Returns a new string with all occurences of `old` replaced with `swap`.
+
+    :::wren
+    var string = "abc abc abc"
+    System.print(string.replace(" ", "")) //> abcabcabc
+
 ### **iterate**(iterator), **iteratorValue**(iterator)
 
 Implements the [iterator protocol](../../control-flow.html#the-iterator-protocol)

--- a/test/core/string/replace.wren
+++ b/test/core/string/replace.wren
@@ -1,0 +1,17 @@
+System.print("something".replace("some", "no")) // expect: nothing
+System.print("something".replace("thing", "one")) // expect: someone
+System.print("something".replace("ometh", "umm"))  // expect: summing
+System.print("something".replace("math", "ton")) // expect: something
+
+// Multiple.
+System.print("somethingsomething".replace("some", "no")) // expect: nothingnothing
+System.print("abc abc abc".replace(" ", "")) // expect: abcabcabc
+System.print("abcabcabc".replace("abc", "")) // expect: 
+
+// Non-ASCII.
+System.print("søméthîng".replace("sømé", "nø"))  // expect: nøthîng
+System.print("søméthîng".replace("meth", "ton")) // expect: søméthîng
+
+// 8-bit clean.
+System.print("a\0b\0c".replace("\0", "")) // expect: abc
+System.print("a\0b\0c".replace("b", "") == "a\0\0c") // expect: true

--- a/test/core/string/replace_empty_old.wren
+++ b/test/core/string/replace_empty_old.wren
@@ -1,0 +1,1 @@
+"foo".replace("", "f") // expect runtime error: Old cannot be empty.

--- a/test/core/string/replace_new_not_string.wren
+++ b/test/core/string/replace_new_not_string.wren
@@ -1,0 +1,1 @@
+"foo".replace("o", 1) // expect runtime error: Argument must be a string.

--- a/test/core/string/replace_old_not_string.wren
+++ b/test/core/string/replace_old_not_string.wren
@@ -1,0 +1,1 @@
+"foo".replace(1, "o") // expect runtime error: Argument must be a string.

--- a/test/core/string/split.wren
+++ b/test/core/string/split.wren
@@ -1,0 +1,16 @@
+System.print("something".split("meth")) // expect: [so, ing]
+System.print("something".split("some")) // expect: [, thing]
+System.print("something".split("ing"))  // expect: [someth, ]
+System.print("something".split("math")) // expect: [something]
+
+// Multiple.
+System.print("somethingsomething".split("meth")) // expect: [so, ingso, ing]
+System.print("abc abc abc".split(" ")) // expect: [abc, abc, abc]
+System.print("abcabcabc".split("abc")) // expect: [, , , ]
+
+// Non-ASCII.
+System.print("søméthîng".split("méth"))  // expect: [sø, îng]
+System.print("søméthîng".split("meth")) // expect: [søméthîng]
+
+// 8-bit clean.
+System.print("a\0b\0c".split("\0")) // expect: [a, b, c]

--- a/test/core/string/split_argument_not_string.wren
+++ b/test/core/string/split_argument_not_string.wren
@@ -1,0 +1,1 @@
+"foo".split(1) // expect runtime error: Argument must be a string.

--- a/test/core/string/split_empty_seperator.wren
+++ b/test/core/string/split_empty_seperator.wren
@@ -1,0 +1,1 @@
+"foo".split("") // expect runtime error: Separator cannot be empty.


### PR DESCRIPTION
Adds `split(_)` and `replace(_,_)` for strings. Tried writing some tests and docs, but I'm not sure how clear they are.