### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/site/embedding/calling-c-from-wren.markdown
+++ b/doc/site/embedding/calling-c-from-wren.markdown
@@ -33,7 +33,7 @@ implemented in C. Both static and instance methods can be foreign.
 When you call a foreign method, Wren needs to figure out which C function to
 execute. This process is called *binding*. Binding is performed on-demand by the
 VM. When a class that declares a foreign method is executed -- when the `class`
-statement itself is evaluated -- the VM askes the host application for the C
+statement itself is evaluated -- the VM asks the host application for the C
 function that should be used for the foreign method.
 
 It does this through the `bindForeignMethodFn` callback you give it when you

--- a/doc/site/modules/core/num.markdown
+++ b/doc/site/modules/core/num.markdown
@@ -152,7 +152,7 @@ It is a runtime error if `other` is not a number.
 
 Performs bitwise or on the number. Both numbers are first converted to 32-bit
 unsigned values. The result is then a 32-bit unsigned number where each bit is
-`true` only where the corresponding bits of both inputs were `true`.
+`true` only where the corresponding bits of one or both inputs were `true`.
 
 It is a runtime error if `other` is not a number.
 


### PR DESCRIPTION
The documentation for the bitwise or operator described the behavior of the bitwise and operator.