### PR TITLE
missing language specifier and variable declaration

### DIFF
--- a/doc/site/embedding/storing-c-data.markdown
+++ b/doc/site/embedding/storing-c-data.markdown
@@ -347,8 +347,10 @@ they already closed. If not, we call `fwrite()` to write to the file.
 
 The other method is `close()` to let them explicitly close the file:
 
+    :::c
     void fileClose(WrenVM* vm)
     {
+      FILE** file = (FILE**)wrenGetSlotForeign(vm, 0);
       closeFile(file);
     }
 


### PR DESCRIPTION
the last C code in the embed doc is missing syntax highlighting and the declaration of the variable used by `closeFile`.