### PR TITLE
Fix embedding path in getting started

### DIFF
--- a/doc/site/getting-started.markdown
+++ b/doc/site/getting-started.markdown
@@ -15,7 +15,7 @@ few dependencies are nice that way. "Wren" encompasses two separate artifacts:
     networking, stuff like that. It depends on [libuv][] for that
     functionality.
 
-[embedded]: embedding-api.html
+[embedded]: embedding
 [libuv]: http://libuv.org/
 
 If you're on a Unix or Mac and you can rock a command line, it's just:


### PR DESCRIPTION
Hey! This is a PR to fix the embedding path in the getting started page. You might need to then re-publish the docs on the gh-pages branch.

Thanks!