### PR TITLE
Fix a documentation error in "Configuring the VM" page

### DIFF
--- a/doc/site/embedding/configuring-the-vm.markdown
+++ b/doc/site/embedding/configuring-the-vm.markdown
@@ -102,6 +102,7 @@ is:
 
     :::c
     void error(
+          WrenVM* vm,
           WrenErrorType type,
           const char* module,
           int line,


### PR DESCRIPTION
The signature of errorFn function pointer (WrenErrorFn) actually has a WrenVM as the first parameter

I realized that this is duplicate of #484 after posting a pull request.