### PR TITLE
Script to measure profile guided and link time optimized builds

### DIFF
--- a/util/pgo.py
+++ b/util/pgo.py
@@ -1,0 +1,239 @@
+from os import listdir, environ, path, chdir
+import re
+import subprocess
+import pickle
+from time import time
+from math import sqrt
+
+
+skip_benchmarks = ["api_call.wren", "api_foreign_method.wren"]
+benchmark_location = 'test/benchmark/'
+
+
+def separate_class(content, idx):
+    in_class = False
+    classes = []
+
+    ret_func = []
+    ret_class = []
+    ret_globals = []
+
+    for line in content.splitlines():
+        # handle conflicting class names
+        if not in_class and line.startswith("class "):
+            in_class = True
+            classes.append(line.split(' ')[1])
+
+        to_add = line
+        for c in classes:
+            rgx = re.compile("[^a-zA-Z]{}[^a-zA-Z]".format(c))
+            column = 0
+            while True:
+                match = rgx.search(to_add, column)
+                if not match:
+                    break
+
+                begin, end = match.span()
+                to_add = "{}{}{}".format(to_add[:begin + 1], c + str(idx), to_add[end - 1:])
+                column = end
+        
+        # handle not global vars that should be
+        if not in_class:
+            stripped = to_add.strip().split(" ")
+            if stripped[0] == 'var' and stripped[1][0].isupper():
+                ret_globals.append(stripped[1])
+                to_add = to_add.replace('var ', '')
+
+        if in_class:
+            ret_class.append(to_add)
+        else:
+            ret_func.append(to_add)
+
+        if in_class and line.startswith("}"):
+            in_class = False
+    
+    return ret_class, ret_func, ret_globals
+
+
+def list_files():
+    to_ret = []
+    for f in listdir(benchmark_location):
+        if f.endswith(".wren") and f not in skip_benchmarks:
+            to_ret.append(f)
+    return to_ret
+
+
+def compile_combined_benchmark(files):
+    contents = []
+    idx = 0
+    global_vars = []
+    for f in files:
+        with open(benchmark_location + f, 'r') as fp:
+            content_class, content_func, glb = separate_class(fp.read(), idx)
+            global_vars.extend(glb)
+
+            header = "// BEGIN {}".format(f)
+            root = "\n".join(content_class)
+            begin = "var t__{} = Fn.new {{\n\tSystem.print(\" ** Start {}\")".format(idx, f)
+            mid = "\n".join("\t{}".format(line) for line in content_func)
+            end = "\tSystem.print(\" ** End {}\")\n}}".format(f)
+            footer = "// END {}".format(f)
+
+            contents.append("\n\n".join((header, root, begin, mid, end, footer)))
+
+        idx += 1
+
+    to_ret = "\n".join("var " + g for g in global_vars)
+    to_ret += "\n"
+    to_ret += "\n\n".join(c for c in contents)
+
+    return to_ret
+        
+
+def write_out_benchmark(filename, content, files, files_to_skip, iterations):
+    clock = "pgo_clock_"
+    meas = "measurements_"
+
+    with open(filename, "w") as fp:
+        fp.write(content)
+        fp.write("\nvar {}\nvar {}\n".format(clock, meas))
+        for i, filename in enumerate(files):
+            if filename in files_to_skip:
+                continue
+            fp.write("{} = []\n".format(meas))
+            fp.write("for (i in 0..{}) {{\n".format(iterations))
+            fp.write("\t{} = System.clock\n".format(clock))
+            fp.write("\tt__{}.call()\n".format(i))
+            fp.write("\t{}.add(System.clock - {})\n".format(meas, clock))
+            fp.write("}\n")
+            fp.write("System.write(\"_PGO_ {} \")\n".format(filename))
+            fp.write("System.print({})\n".format(meas))
+
+
+def check_call(cmd, env={}):
+    print("Running {} with env {} ...".format(cmd, env), end=" ", flush=True)
+    env = {**environ.copy(), **env}
+
+    t = time()
+    ps = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if ps.wait() != 0:
+        print(ps.communicate()[1].decode())
+        raise ValueError("Command returned non zero!")
+
+    print("{:.4f}".format(time() - t))
+    return ps.communicate()[0]
+
+
+def touch_all():
+    check_call(["find", "-type", "f", "-exec", "touch", "{}", "+"])
+
+
+def make_pgo(filename, more_cflags=""):
+    check_call(["make", "clean"], {})
+    check_call(["make"], {'WREN_CFLAGS': '-fprofile-generate ' + more_cflags})
+    check_call(["./wren", filename])
+    touch_all()
+    check_call(["make"], {'WREN_CFLAGS': '-fprofile-use -w ' + more_cflags})
+
+
+def make_no_pgo(more_cflags=""):
+    check_call(["make", "clean"], {})
+    check_call(["make"], {'WREN_CFLAGS': more_cflags})
+
+
+def measure(filename, cmd="./wren"):
+    out = check_call([cmd, filename]).decode()
+    to_ret = []
+    for line in out.splitlines():
+        if "_PGO_" in line:
+            splt = line.split(" ")
+            data = eval("".join(splt[2:]))
+
+            mean = sum(data) / len(data)
+            stddev = sqrt(sum((x - mean) ** 2 for x in data) / (len(data) - 1))
+
+            to_ret.append((mean, stddev))
+
+    return to_ret
+
+
+if __name__ == "__main__":
+    parent_path = "/".join(path.realpath(__file__).split("/")[:-2])
+    chdir(parent_path)
+
+    bench_make = "_pgo_make.wren"
+    bench_measure = "_pgo_measure.wren"
+    results_file = "_pgo_results.p"
+
+    MAKE_ITERS = 4
+    MEASURE_ITERS = 40
+
+    data = {}
+    files = list_files()
+    half = len(files) // 2
+
+    if False:
+        content = compile_combined_benchmark(files)
+        write_out_benchmark(bench_make, content, files, [], MAKE_ITERS)
+        write_out_benchmark(bench_measure, content, files, [], MEASURE_ITERS)
+
+        print("1 / 7")
+        make_no_pgo()
+        data["release"] = measure(bench_measure)
+
+        print("2 / 7")
+        make_no_pgo("-flto")
+        data["release-lto"] = measure(bench_measure)
+        
+        print("3 / 7")
+        make_pgo(bench_make)
+        data["pgo"] = measure(bench_measure)
+
+        print("4 / 7")
+        make_pgo(bench_make, "-flto")
+        data["pgo-lto"] = measure(bench_measure)
+
+        print("5 / 7")
+        data["system"] = measure(bench_measure, cmd="wren")
+
+        print("6 / 7")
+        write_out_benchmark(bench_make, content, files, files[:half], MAKE_ITERS)
+        make_pgo(bench_make)
+        data["1/2"] = measure(bench_measure)
+
+        print("7 / 7")
+        write_out_benchmark(bench_make, content, files, files[half:], MAKE_ITERS)
+        make_pgo(bench_make)
+        data["2/2"] = measure(bench_measure)
+
+        with open(results_file, "wb") as fp:
+            pickle.dump(data, fp)
+
+    else:
+        with open(results_file, "rb") as fp:
+            data = pickle.load(fp)
+
+    print("*** Results ***")
+    fmt = "{:18}"
+
+    # header
+    print(fmt.format("*"), end=" ")
+    for f in files:
+        print(fmt.format(f[:-5]), end=" ")
+    print(fmt.format("AVG"))
+
+    # cells
+    for data_name, meas in data.items():
+        mean_sum = 0
+        variance_sum = 0
+        print(fmt.format(data_name), end=" ")
+        for m in meas:
+            strm = "{:.5f}±{:.5f}".format(*m)
+            mean_sum += m[0]
+            variance_sum += m[1] * m[1]
+            print(fmt.format(strm), end=" ")
+
+        stddev = sqrt(variance_sum) / len(meas)
+        print("{:.5f}±{:.5f}".format(mean_sum / len(meas), stddev))
+
+


### PR DESCRIPTION
This is not meant to be merged. I was just wondering how fast lto and [pgo](https://en.wikipedia.org/wiki/Profile-guided_optimization) builds are. I compiled all the benchmarks into one file and used that for guidance in pgo builds and also to measure speed.

Results:

``` 
                   fib                fibers             map_numeric        binary_trees       for                string_equals      binary_trees_gc    method_call        delta_blue         map_string         AVG               
release            0.24745±0.00046    0.08036±0.00885    0.41432±0.00347    0.29134±0.00570    0.15414±0.00060    0.23351±0.00151    1.47808±0.05753    0.18523±0.00038    0.23841±0.00055    0.30330±0.00728    0.36262±0.00591
release-lto        0.23254±0.00858    0.07594±0.00859    0.38696±0.00307    0.29208±0.00753    0.14638±0.00065    0.27242±0.00079    1.43138±0.09396    0.18792±0.00065    0.25018±0.00070    0.32770±0.02043    0.36035±0.00973
pgo                0.22345±0.00065    0.06927±0.00842    0.23666±0.00379    0.24100±0.00509    0.08944±0.00070    0.19712±0.00218    1.48391±0.07824    0.11127±0.00054    0.17983±0.00073    0.29425±0.00864    0.31262±0.00795
pgo-lto            0.26572±0.00542    0.06638±0.00890    0.22017±0.00313    0.23163±0.00616    0.07930±0.00061    0.19131±0.00083    1.35874±0.10156    0.10848±0.00062    0.17323±0.00094    0.28506±0.00969    0.29800±0.01028
system             0.24335±0.00588    0.07445±0.00908    0.41158±0.00371    0.29214±0.00478    0.15132±0.00204    0.23327±0.00320    1.51181±0.08050    0.17340±0.00077    0.23388±0.00111    0.33209±0.00863    0.36573±0.00820
1/2                0.23026±0.00134    0.07279±0.00906    0.23840±0.00387    0.24031±0.00621    0.08586±0.00083    0.19854±0.00088    1.44298±0.09712    0.15389±0.00102    0.18177±0.00089    0.29835±0.00986    0.31431±0.00983
2/2                0.22808±0.00862    0.07429±0.00909    0.23131±0.00371    0.24464±0.00630    0.08462±0.00064    0.21489±0.00133    1.45057±0.09019    0.11213±0.00093    0.18299±0.00084    0.30232±0.00869    0.31258±0.00918
```

The rows contain execution speeds for different benchmark programs. Every row is measured with its own build. These are (these commands are not functional, but you get the idea):

* release: `$make release`
* lto: `WREN_FLAGS='-flto' make`
* pgo: `WREN_FLAGS='-fprofile-generate' make && ./wren measure.wren && WREN_FLAGS='-fprofile-use' make`
* system: wren from arch linux repository
* 1/2 and 2/2 are pgo builds, where only first 5 or second five benchmarks are used for guidance, no lto.

PS. Good job to everyone on the language!