### PR TITLE
introduced docs auto publish step to travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
   include:
     - stage: deploy
       script: bash util/deployGHP.sh
+      if: branch = master
 
 # Travis VMs are 64-bit but we compile both for 32 and 64 bit. To enable the
 # 32-bit builds to work, we need gcc-multilib.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: c
 os:
- - osx
  - linux
+ - osx
 compiler:
   - gcc
   - clang
 env:
   - WREN_OPTIONS="" CI_ARCHS="ci_32 ci_64"
   - WREN_OPTIONS="-DWREN_NAN_TAGGING=0" CI_ARCHS="ci_64"
+
+jobs:
+  include:
+    - stage: deploy
+      script: bash util/deployGHP.sh
+
 # Travis VMs are 64-bit but we compile both for 32 and 64 bit. To enable the
 # 32-bit builds to work, we need gcc-multilib.
 addons:
@@ -15,5 +21,8 @@ addons:
     packages:
     - gcc-multilib
     - g++-multilib
+    - python3-markdown
+    - ruby-sass
+
 sudo: false # Enable container-based builds.
 script: make WREN_CFLAGS=${WREN_OPTIONS} ${CI_ARCHS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
   include:
     - stage: deploy
       script: bash util/deployGHP.sh
-      if: branch = master
+      if: branch = master AND NOT type IN (pull_request)
 
 # Travis VMs are 64-bit but we compile both for 32 and 64 bit. To enable the
 # 32-bit builds to work, we need gcc-multilib.

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ benchmark: release
 
 # Generate the Wren site.
 docs:
+	mkdir -p build
 	$(V) ./util/generate_docs.py
 
 # Continuously generate and serve the Wren site.

--- a/util/deployGHP.sh
+++ b/util/deployGHP.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+make gh-pages
+
+git clone https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG} gh-pages-repo
+cd gh-pages-repo
+git checkout gh-pages
+
+rm -rf *
+cp -r ../build/gh-pages/* .
+
+git status
+ls 
+
+if ! $( git diff-index --quiet HEAD ) ; then
+	git config user.name "Travis CI"
+	git config user.email "$COMMIT_AUTHOR_EMAIL"
+	git add -A .
+	git commit -m "Deploy to GitHub Pages: ${SHA}"
+	git push 
+fi


### PR DESCRIPTION
As a user of wren, I want to be able to read up to date docs for wren online
As a potential contributor to wren, I want to know that my PRs to the docs will be useful.

This PR introduces a job to TravisCI to auto build and publish the wren docs to the `gh-pages` branch of the repo; ensuring the published docs stay up-to-date