### PR TITLE
documentation: fixed typo, function declares data, body uses file

### DIFF
--- a/doc/site/embedding/storing-c-data.markdown
+++ b/doc/site/embedding/storing-c-data.markdown
@@ -270,7 +270,7 @@ and closes the file:
     :::c
     void fileFinalize(void* data)
     {
-      closeFile((FILE**)file);
+      closeFile((FILE**) data);
     }
 
 It uses this little utility function:


### PR DESCRIPTION
Small improvement of documentation.

Currently is:
```
    void fileFinalize(void* data)
    {
      closeFile((FILE**)file);
    }
```
 It's wrong. `data` are declared, but `file` is in body.

Correct is:
```
    void fileFinalize(void* data)
    {
      closeFile((FILE**) data);
    }
```
