### PR TITLE
Skip UTF-8 byte order mark

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3446,12 +3446,11 @@ ObjFn* wrenCompile(WrenVM* vm, ObjModule* module, const char* source,
   parser.printErrors = printErrors;
   parser.hasError = false;
 
-
   // Read the first token.
   nextToken(&parser);
 
   int numExistingVariables = module->variables.count;
-  
+
   Compiler compiler;
   initCompiler(&compiler, &parser, NULL, true);
   ignoreNewlines(&compiler);

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3416,20 +3416,27 @@ void definition(Compiler* compiler)
 ObjFn* wrenCompile(WrenVM* vm, ObjModule* module, const char* source,
                    bool isExpression, bool printErrors)
 {
+  // Skip potential UTF-8 BOM
+  size_t sourceOffset = 0;
+  if (source[0] == (char) 0xef && source[1] == (char) 0xbb && source[2] == (char) 0xbf)
+  {
+    sourceOffset = 3;
+  }
+
   Parser parser;
   parser.vm = vm;
   parser.module = module;
-  parser.source = source;
+  parser.source = source + sourceOffset;
 
-  parser.tokenStart = source;
-  parser.currentChar = source;
+  parser.tokenStart = source + sourceOffset;
+  parser.currentChar = source + sourceOffset;
   parser.currentLine = 1;
   parser.numParens = 0;
 
   // Zero-init the current token. This will get copied to previous when
   // advance() is called below.
   parser.current.type = TOKEN_ERROR;
-  parser.current.start = source;
+  parser.current.start = source + sourceOffset;
   parser.current.length = 0;
   parser.current.line = 0;
   parser.current.value = UNDEFINED_VAL;
@@ -3438,6 +3445,7 @@ ObjFn* wrenCompile(WrenVM* vm, ObjModule* module, const char* source,
   parser.skipNewlines = true;
   parser.printErrors = printErrors;
   parser.hasError = false;
+
 
   // Read the first token.
   nextToken(&parser);

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3417,26 +3417,25 @@ ObjFn* wrenCompile(WrenVM* vm, ObjModule* module, const char* source,
                    bool isExpression, bool printErrors)
 {
   // Skip potential UTF-8 BOM
-  size_t sourceOffset = 0;
-  if (source[0] == (char) 0xef && source[1] == (char) 0xbb && source[2] == (char) 0xbf)
+  if (strncmp(source, "\xEF\xBB\xBF", 3) == 0)
   {
-    sourceOffset = 3;
+    source += 3;
   }
 
   Parser parser;
   parser.vm = vm;
   parser.module = module;
-  parser.source = source + sourceOffset;
+  parser.source = source;
 
-  parser.tokenStart = source + sourceOffset;
-  parser.currentChar = source + sourceOffset;
+  parser.tokenStart = source;
+  parser.currentChar = source;
   parser.currentLine = 1;
   parser.numParens = 0;
 
   // Zero-init the current token. This will get copied to previous when
   // advance() is called below.
   parser.current.type = TOKEN_ERROR;
-  parser.current.start = source + sourceOffset;
+  parser.current.start = source;
   parser.current.length = 0;
   parser.current.line = 0;
   parser.current.value = UNDEFINED_VAL;

--- a/test/regression/520.wren
+++ b/test/regression/520.wren
@@ -1,0 +1,2 @@
+﻿// This file should have a UTF-8 byte order mark
+System.print("ok") // expect: ok


### PR DESCRIPTION
#520 Skips the Unicode UTF-8 BOM by adding a 3-byte offset when compiling. Tested by running a few scripts with and without the BOM.