### PR TITLE
Update calls to wrenInterpret in documentation

### DIFF
--- a/doc/site/embedding/index.markdown
+++ b/doc/site/embedding/index.markdown
@@ -131,7 +131,7 @@ VM, waiting to run some code!
 You execute a string of Wren source code like so:
 
     :::c
-    WrenInterpretResult result = wrenInterpret(vm,
+    WrenInterpretResult result = wrenInterpret(vm, NULL,
         "System.print(\"I am running in a VM!\")");
 
 The string is a series of one or more statements separated by newlines. Wren

--- a/doc/site/embedding/storing-c-data.markdown
+++ b/doc/site/embedding/storing-c-data.markdown
@@ -207,7 +207,7 @@ Over in the host, first we'll set up the VM:
       config.bindForeignMethodFn = bindForeignMethod;
 
       WrenVM* vm = wrenNewVM(&config);
-      wrenInterpret(vm, "some code...");
+      wrenInterpret(vm, NULL, "some code...");
 
       return 0;
     }


### PR DESCRIPTION
wrenInterpret now takes a `const char* module` parameter.