### PR TITLE
Better Random objects with default seeding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  linux:
+    name: Linux Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Build (Debug 64-bit)
+      run: make -C projects/make config=debug_64bit
+
+    - name: Run tests (Debug)
+      run: python3 util/test.py --suffix=_d
+
+    - name: Build (Release 64-bit)
+      run: make -C projects/make config=release_64bit
+
+    - name: Run tests (Release)
+      run: python3 util/test.py
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: wren-linux
+        path: |
+          bin/*
+          lib/*
+
+  macos:
+    name: macOS Build & Test
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Build (Debug 64-bit)
+      run: make -C projects/make.mac config=debug_64bit
+
+    - name: Run tests (Debug)
+      run: python3 util/test.py --suffix=_d
+
+    - name: Build (Release 64-bit)
+      run: make -C projects/make.mac config=release_64bit
+
+    - name: Run tests (Release)
+      run: python3 util/test.py
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: wren-macos
+        path: |
+          bin/*
+          lib/*
+
+  windows:
+    name: Windows Build & Test
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Build (Release 64-bit)
+      working-directory: projects/vs2019
+      run: msbuild wren.sln /p:Configuration=Release /p:Platform=64bit
+
+    - name: Run tests (Release)
+      run: python util/test.py
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: wren-windows
+        path: |
+          bin/*
+          lib/*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+### This fork allows for type annotations in the language
+The compiler just skips them, but external tools can be used to provide diagnostics.
+
+```dart
+var val : Num = 0
+
+class Wren {
+   add(a : Num, b : Num) -> Num { a + b }
+}
+```
+
 ## Wren is a small, fast, class-based concurrent scripting language
 
 Think Smalltalk in a Lua-sized package with a dash of Erlang and wrapped up in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### This fork allows for type annotations in the language
+### Note - This fork allows for type annotations in the language
 The compiler just skips them, but external tools can be used to provide diagnostics.
 
 ```dart
@@ -8,6 +8,11 @@ class Wren {
    add(a : Num, b : Num) -> Num { a + b }
 }
 ```
+You can use the standalone [wren-analyzer] or [wren-vscode] integration. 
+
+[wren-analyzer]: https://github.com/enci/wren-analyzer
+[wren-vscode]: https://marketplace.visualstudio.com/items?itemName=BojanEndrovski.wren
+
 
 ## Wren is a small, fast, class-based concurrent scripting language
 

--- a/src/optional/wren_opt_random.c
+++ b/src/optional/wren_opt_random.c
@@ -47,7 +47,7 @@ static void randomSeed0(WrenVM* vm)
 {
   Well512* well = (Well512*)wrenGetSlotForeign(vm, 0);
 
-  srand((uint32_t)time(NULL));
+  srand((uint32_t)time(NULL) + (uint32_t)clock());
   for (int i = 0; i < 16; i++)
   {
     well->state[i] = rand();

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1868,6 +1868,7 @@ static void finishParameterList(Compiler* compiler, Signature* signature)
 
     // Define a local variable in the method for the parameter.
     declareNamedVariable(compiler);
+    consumeTypeAnnotation(compiler); // [WREN_TYPE_ANNOTATIONS] param: Type
   }
   while (match(compiler, TOKEN_COMMA));
 }

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3096,6 +3096,8 @@ static void forStatement(Compiler* compiler)
   const char* name = compiler->parser->previous.start;
   int length = compiler->parser->previous.length;
 
+  consumeTypeAnnotation(compiler); // [WREN_TYPE_ANNOTATIONS] for (i: Type in ...)
+
   consume(compiler, TOKEN_IN, "Expect 'in' after loop variable.");
   ignoreNewlines(compiler);
 

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1293,6 +1293,28 @@ static void ignoreNewlines(Compiler* compiler)
   matchLine(compiler);
 }
 
+// [WREN_TYPE_ANNOTATIONS] Optionally consumes a colon-based type annotation
+// (": TypeName") after a variable name or parameter. The annotation is parsed
+// and discarded (no effect on code generation).
+static void consumeTypeAnnotation(Compiler* compiler)
+{
+  if (match(compiler, TOKEN_COLON))
+  {
+    consume(compiler, TOKEN_NAME, "Expect type name after ':'.");
+  }
+}
+
+// [WREN_TYPE_ANNOTATIONS] Optionally consumes a return type annotation
+// ("-> TypeName") after a method signature. The annotation is parsed and
+// discarded (no effect on code generation).
+static void consumeReturnTypeAnnotation(Compiler* compiler)
+{
+  if (match(compiler, TOKEN_ARROW))
+  {
+    consume(compiler, TOKEN_NAME, "Expect return type name after '->'.");
+  }
+}
+
 // Consumes the current token. Emits an error if it is not a newline. Then
 // discards any duplicate newlines following it.
 static void consumeLine(Compiler* compiler, const char* errorMessage)
@@ -3711,6 +3733,8 @@ static void variableDefinition(Compiler* compiler)
   // in scope in its own initializer.
   consume(compiler, TOKEN_NAME, "Expect variable name.");
   Token nameToken = compiler->parser->previous;
+
+  consumeTypeAnnotation(compiler); // [WREN_TYPE_ANNOTATIONS] var x: Type
 
   // Compile the initializer.
   if (match(compiler, TOKEN_EQ))

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3489,6 +3489,8 @@ static bool method(Compiler* compiler, Variable classVariable)
   // Compile the method signature.
   signatureFn(&methodCompiler, &signature);
 
+  consumeReturnTypeAnnotation(compiler); // [WREN_TYPE_ANNOTATIONS] -> ReturnType
+
   methodCompiler.isInitializer = signature.type == SIG_INITIALIZER;
   
   if (isStatic && signature.type == SIG_INITIALIZER)

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -69,6 +69,7 @@ typedef enum
   TOKEN_HASH,
   TOKEN_PLUS,
   TOKEN_MINUS,
+  TOKEN_ARROW,       // [WREN_TYPE_ANNOTATIONS] ->
   TOKEN_LTLT,
   TOKEN_GTGT,
   TOKEN_PIPE,
@@ -1108,7 +1109,7 @@ static void nextToken(Parser* parser)
       }
       case '^': makeToken(parser, TOKEN_CARET); return;
       case '+': makeToken(parser, TOKEN_PLUS); return;
-      case '-': makeToken(parser, TOKEN_MINUS); return;
+      case '-': twoCharToken(parser, '>', TOKEN_ARROW, TOKEN_MINUS); return; // [WREN_TYPE_ANNOTATIONS]
       case '~': makeToken(parser, TOKEN_TILDE); return;
       case '?': makeToken(parser, TOKEN_QUESTION); return;
         
@@ -2771,6 +2772,7 @@ GrammarRule rules[] =
   /* TOKEN_HASH          */ UNUSED,
   /* TOKEN_PLUS          */ INFIX_OPERATOR(PREC_TERM, "+"),
   /* TOKEN_MINUS         */ OPERATOR("-"),
+  /* TOKEN_ARROW         */ UNUSED,                                       // [WREN_TYPE_ANNOTATIONS]
   /* TOKEN_LTLT          */ INFIX_OPERATOR(PREC_BITWISE_SHIFT, "<<"),
   /* TOKEN_GTGT          */ INFIX_OPERATOR(PREC_BITWISE_SHIFT, ">>"),
   /* TOKEN_PIPE          */ INFIX_OPERATOR(PREC_BITWISE_OR, "|"),

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -2635,6 +2635,7 @@ void infixSignature(Compiler* compiler, Signature* signature)
   // Parse the parameter name.
   consume(compiler, TOKEN_LEFT_PAREN, "Expect '(' after operator name.");
   declareNamedVariable(compiler);
+  consumeTypeAnnotation(compiler); // [WREN_TYPE_ANNOTATIONS]
   consume(compiler, TOKEN_RIGHT_PAREN, "Expect ')' after parameter name.");
 }
 
@@ -2660,6 +2661,7 @@ void mixedSignature(Compiler* compiler, Signature* signature)
 
     // Parse the parameter name.
     declareNamedVariable(compiler);
+    consumeTypeAnnotation(compiler); // [WREN_TYPE_ANNOTATIONS]
     consume(compiler, TOKEN_RIGHT_PAREN, "Expect ')' after parameter name.");
   }
 }
@@ -2685,6 +2687,7 @@ static bool maybeSetter(Compiler* compiler, Signature* signature)
   // Parse the value parameter.
   consume(compiler, TOKEN_LEFT_PAREN, "Expect '(' after '='.");
   declareNamedVariable(compiler);
+  consumeTypeAnnotation(compiler); // [WREN_TYPE_ANNOTATIONS]
   consume(compiler, TOKEN_RIGHT_PAREN, "Expect ')' after parameter name.");
 
   signature->arity++;

--- a/test/language/type_annotation/annotation_with_custom_class.wren
+++ b/test/language/type_annotation/annotation_with_custom_class.wren
@@ -1,0 +1,22 @@
+class Point {
+  construct new(x: Num, y: Num) {
+    _x = x
+    _y = y
+  }
+
+  x -> Num { _x }
+  y -> Num { _y }
+  toString { "(%(_x), %(_y))" }
+
+  +(other: Point) -> Point {
+    return Point.new(_x + other.x, _y + other.y)
+  }
+}
+
+var p1: Point = Point.new(1, 2)
+var p2: Point = Point.new(3, 4)
+var p3: Point = p1 + p2
+
+System.print(p1) // expect: (1, 2)
+System.print(p2) // expect: (3, 4)
+System.print(p3) // expect: (4, 6)

--- a/test/language/type_annotation/block_parameter_annotation.wren
+++ b/test/language/type_annotation/block_parameter_annotation.wren
@@ -1,0 +1,4 @@
+var fn = Fn.new {|x: Num|
+  return x * 2
+}
+System.print(fn.call(21)) // expect: 42

--- a/test/language/type_annotation/constructor_annotation.wren
+++ b/test/language/type_annotation/constructor_annotation.wren
@@ -1,0 +1,10 @@
+class Foo {
+  construct new(name: String, age: Num) {
+    _name = name
+    _age = age
+  }
+
+  toString { _name + " is " + _age.toString }
+}
+
+System.print(Foo.new("Alice", 30)) // expect: Alice is 30

--- a/test/language/type_annotation/for_loop_annotation.wren
+++ b/test/language/type_annotation/for_loop_annotation.wren
@@ -1,0 +1,6 @@
+for (i: Num in 1..3) {
+  System.print(i)
+}
+// expect: 1
+// expect: 2
+// expect: 3

--- a/test/language/type_annotation/getter_return_type.wren
+++ b/test/language/type_annotation/getter_return_type.wren
@@ -1,0 +1,10 @@
+class Foo {
+  construct new(val) {
+    _val = val
+  }
+
+  val -> Num { _val }
+}
+
+var foo = Foo.new(42)
+System.print(foo.val) // expect: 42

--- a/test/language/type_annotation/method_parameter_annotation.wren
+++ b/test/language/type_annotation/method_parameter_annotation.wren
@@ -1,0 +1,15 @@
+class Foo {
+  construct new() {}
+
+  add(a: Num, b: Num) {
+    return a + b
+  }
+
+  greet(name: String) {
+    return "hi " + name
+  }
+}
+
+var foo = Foo.new()
+System.print(foo.add(1, 2)) // expect: 3
+System.print(foo.greet("world")) // expect: hi world

--- a/test/language/type_annotation/method_return_type.wren
+++ b/test/language/type_annotation/method_return_type.wren
@@ -1,0 +1,15 @@
+class Foo {
+  construct new() {}
+
+  greet(name: String) -> String {
+    return "Hello, " + name
+  }
+
+  add(a: Num, b: Num) -> Num {
+    return a + b
+  }
+}
+
+var foo = Foo.new()
+System.print(foo.greet("World")) // expect: Hello, World
+System.print(foo.add(1, 2)) // expect: 3

--- a/test/language/type_annotation/missing_type_after_arrow.wren
+++ b/test/language/type_annotation/missing_type_after_arrow.wren
@@ -1,0 +1,7 @@
+// expect error line 6
+// expect error line 6
+// expect error line 8
+class Foo {
+  construct new() {}
+  bar() -> {}
+}

--- a/test/language/type_annotation/missing_type_after_colon.wren
+++ b/test/language/type_annotation/missing_type_after_colon.wren
@@ -1,0 +1,1 @@
+var x: = 42 // expect error

--- a/test/language/type_annotation/mixed_annotations.wren
+++ b/test/language/type_annotation/mixed_annotations.wren
@@ -1,0 +1,30 @@
+class Greeter {
+  construct new(name: String) {
+    _name = name
+  }
+
+  greet(greeting: String) -> String {
+    return greeting + ", " + _name
+  }
+
+  name -> String { _name }
+  name=(value: String) { _name = value }
+}
+
+var g: Greeter = Greeter.new("World")
+System.print(g.greet("Hello")) // expect: Hello, World
+System.print(g.name) // expect: World
+g.name = "Wren"
+System.print(g.name) // expect: Wren
+
+for (i: Num in 1..3) {
+  System.print(i)
+}
+// expect: 1
+// expect: 2
+// expect: 3
+
+var fn: Fn = Fn.new {|x: Num|
+  return x * 2
+}
+System.print(fn.call(5)) // expect: 10

--- a/test/language/type_annotation/operator_annotation.wren
+++ b/test/language/type_annotation/operator_annotation.wren
@@ -1,0 +1,10 @@
+class Vec {
+  construct new(x) { _x = x }
+  +(other: Vec) { Vec.new(_x + other.x) }
+  -(other: Vec) { Vec.new(_x - other.x) }
+  x { _x }
+  toString { _x.toString }
+}
+
+System.print(Vec.new(3) + Vec.new(4)) // expect: 7
+System.print(Vec.new(10) - Vec.new(3)) // expect: 7

--- a/test/language/type_annotation/setter_annotation.wren
+++ b/test/language/type_annotation/setter_annotation.wren
@@ -1,0 +1,12 @@
+class Foo {
+  construct new() {
+    _val = 0
+  }
+
+  val=(v: Num) { _val = v }
+  val { _val }
+}
+
+var foo = Foo.new()
+foo.val = 42
+System.print(foo.val) // expect: 42

--- a/test/language/type_annotation/subscript_annotation.wren
+++ b/test/language/type_annotation/subscript_annotation.wren
@@ -1,0 +1,11 @@
+class Grid {
+  construct new() {
+    _data = [1, 2, 3, 4]
+  }
+
+  [index: Num] { _data[index] }
+}
+
+var g = Grid.new()
+System.print(g[0]) // expect: 1
+System.print(g[2]) // expect: 3

--- a/test/language/type_annotation/variable_annotation.wren
+++ b/test/language/type_annotation/variable_annotation.wren
@@ -1,0 +1,14 @@
+var x: Num = 42
+System.print(x) // expect: 42
+
+var s: String = "hello"
+System.print(s) // expect: hello
+
+var b: Bool = true
+System.print(b) // expect: true
+
+// Without initializer, should default to null.
+{
+  var n: Num
+  System.print(n) // expect: null
+}

--- a/test/language/type_annotation/variable_no_annotation.wren
+++ b/test/language/type_annotation/variable_no_annotation.wren
@@ -1,0 +1,11 @@
+// Regression: existing syntax without type annotations still works.
+var x = 42
+System.print(x) // expect: 42
+
+var s = "hello"
+System.print(s) // expect: hello
+
+{
+  var n
+  System.print(n) // expect: null
+}


### PR DESCRIPTION
The no args constructor for Random creates an objects with the same seed within the same second, because `time()` has second resolution. Adding `clock()` to the seed removes this implicit and undocumented behavior.