### PR TITLE
Add check for method limit; closes #1193

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,4 +29,5 @@ ruby0x1 <ruby0x1@pm.me>
 Kolja Kube <code@koljaku.be>
 Alexander Klingenbeck <alexander.klingenbeck@gmx.de>
 Aviv Beeri <avbeeri@gmail.com>
+Mai Lapyst <floss@lapyst.dev>
 

--- a/src/vm/wren_common.h
+++ b/src/vm/wren_common.h
@@ -113,6 +113,9 @@
 // field index*.
 #define MAX_FIELDS 255
 
+// The maximum number of methods the vm can handle.
+#define MAX_METHODS 65535
+
 // Use the VM's allocator to allocate an object of [type].
 #define ALLOCATE(vm, type)                                                     \
     ((type*)wrenReallocate(vm, NULL, 0, sizeof(type)))

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1852,8 +1852,14 @@ static void finishParameterList(Compiler* compiler, Signature* signature)
 // Gets the symbol for a method [name] with [length].
 static int methodSymbol(Compiler* compiler, const char* name, int length)
 {
-  return wrenSymbolTableEnsure(compiler->parser->vm,
+  int symbol = wrenSymbolTableEnsure(compiler->parser->vm,
       &compiler->parser->vm->methodNames, name, length);
+
+  if (symbol > MAX_METHODS) {
+    error(compiler, "Method limit of %d reached.", MAX_METHODS);
+  }
+
+  return symbol;
 }
 
 // Appends characters to [name] (and updates [length]) for [numParams] "_"

--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1418,6 +1418,7 @@ WrenHandle* wrenMakeCallHandle(WrenVM* vm, const char* signature)
   // Add the signatue to the method table.
   int method =  wrenSymbolTableEnsure(vm, &vm->methodNames,
                                       signature, signatureLength);
+  ASSERT(method <= MAX_METHODS, "Method limit reached.");
   
   // Create a little stub function that assumes the arguments are on the stack
   // and calls the method.


### PR DESCRIPTION
Adds a check to the main two places that create bytecode referencing the slot inside the `methodNames` list.

There are only two instances left that are unchecked, both inside `bindForeignClass`, but It seems that it's not used in any code involing generating bytecode.
