### PR TITLE
Feat: Expose caller information to foreign functions

### DIFF
--- a/src/vm/wren_vm.c
+++ b/src/vm/wren_vm.c
@@ -1074,6 +1074,7 @@ static WrenInterpretResult runInterpreter(WrenVM* vm, register ObjFiber* fiber)
           break;
 
         case METHOD_FOREIGN:
+          STORE_FRAME();
           callForeign(vm, fiber, method->as.foreign, numArgs);
           if (wrenHasError(fiber)) RUNTIME_ERROR();
           break;


### PR DESCRIPTION
This change enhances the foreign function interface by allowing foreign functions to inspect their call site within the Wren VM.

By saving the VM's state with `STORE_FRAME()` before a foreign call, the foreign function can now access the caller's context, including the instruction pointer. This allows for runtime reflection, such as determining the method name that was used to invoke the foreign function by inspecting the bytecode.

This enables more advanced use cases for foreign functions that require information about their invocation context. The `LOAD_FRAME()` macro ensures that the VM state is correctly restored after the foreign function returns, maintaining the integrity of the interpreter.

Also, it breaks no test.