### PR TITLE
Fix buffer overflow with string parsing in peekChar (fixes #1217).

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -653,7 +653,9 @@ static char peekNextChar(Parser* parser)
 static char nextChar(Parser* parser)
 {
   char c = peekChar(parser);
-  parser->currentChar++;
+  // Do not move the character pointer forward if we're at
+  // the end.
+  if (c != '\0') parser->currentChar++;
   if (c == '\n') parser->currentLine++;
   return c;
 }


### PR DESCRIPTION
### Summary ###
Fixes a buffer overflow in `peekChar` within `wren_compiler.c` triggered when parsing improperly formatted raw strings.

### Root Cause ###
`nextChar` increments `parser->currentChar` unconditionally, even when the parser has already reached the end of the source (the \0 terminator).
After this increment, `currentChar` may point past the valid buffer. When `peekChar` is later called, it dereferences this invalid pointer, causing the overflow.

This surfaces most clearly in readRawString, since it repeatedly calls `nextChar` and `peekChar` without intermediate null‑byte checks, but the underlying issue is general to the parser (more specifically, `nextChar` itself).

### Fix ###
`nextChar` now checks whether the next character is the null terminator. If so, it does not advance `parser->currentChar`.
This prevents the pointer from ever moving past the end of the source buffer and eliminates the invalid dereference in `peekChar`.

### Testing ###
- All tests pass (ran test script: util/test.py).
- ASAN no longer reports the buffer overflow when running the provided C + Wren test harness (I personally confirmed the overflow with the original version of `nextChar`).