### PR TITLE
Fix buffer overflow with argument parsing (fixes #1219).

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -1823,15 +1823,21 @@ static void finishBody(Compiler* compiler)
 
 // The VM can only handle a certain number of parameters, so check that we
 // haven't exceeded that and give a usable error.
-static void validateNumParameters(Compiler* compiler, int numArgs)
+static bool validateNumParameters(Compiler* compiler, int numArgs)
 {
+  // Since we always pass arity + 1 (and arity >= 0), numArgs == 0
+  // -> we hit a prior error and don't want to report again.
+  if (numArgs == 0) return false;
   if (numArgs == MAX_PARAMETERS + 1)
   {
     // Only show an error at exactly max + 1 so that we can keep parsing the
     // parameters and minimize cascaded errors.
     error(compiler, "Methods cannot have more than %d parameters.",
           MAX_PARAMETERS);
+    return false;
   }
+
+  return true;
 }
 
 // Parses the rest of a comma-separated parameter list after the opening
@@ -1841,7 +1847,11 @@ static void finishParameterList(Compiler* compiler, Signature* signature)
   do
   {
     ignoreNewlines(compiler);
-    validateNumParameters(compiler, ++signature->arity);
+
+    if (!validateNumParameters(compiler, ++signature->arity))
+    {
+      signature->arity = -1;
+    }
 
     // Define a local variable in the method for the parameter.
     declareNamedVariable(compiler);
@@ -1967,7 +1977,12 @@ static void finishArgumentList(Compiler* compiler, Signature* signature)
   do
   {
     ignoreNewlines(compiler);
-    validateNumParameters(compiler, ++signature->arity);
+
+    if (!validateNumParameters(compiler, ++signature->arity))
+    {
+      signature->arity = -1;
+    }
+
     expression(compiler);
   }
   while (match(compiler, TOKEN_COMMA));
@@ -2525,7 +2540,11 @@ static void subscript(Compiler* compiler, bool canAssign)
     signature.type = SIG_SUBSCRIPT_SETTER;
 
     // Compile the assigned value.
-    validateNumParameters(compiler, ++signature.arity);
+    if (!validateNumParameters(compiler, ++signature.arity))
+    {
+      signature.arity = -1;
+    }
+
     expression(compiler);
   }
 


### PR DESCRIPTION
### Summary ###
Given enough comma-separated arguments (in lists, functions, etc.), a buffer overflow is triggered when `emitOp` (called from within `emitShortArg` from `callSignature`) is called (eventually).

### Root Cause ###
The calls to `validateNumParameters` in multiple locations unconditionally increments the signature arity (`signature->arity`). While this does prevent the function from reporting a _"Methods cannot have more than 16 parameters"_ error more than once for a particular parsing phase, it causes the arity field to increase without bound.

In `callSignature` called from `subscript`, this arity is then added to the instruction `CODE_CALL_0`, which has integer equivalent value 24. With enough commas, the arity in the signature can increase to 53, which causes this sum to equal 77. The sum is then used in `emitOp` called from `emitShortArg` (called from `callSignature`) as an index into stackEffects, which only contains 77 elements. Thus, any arity value of 53 or higher leads to an out-of-index buffer overflow error.

In the Wren test script used in the issue, the arity reaches 54 before the buffer overflow occurs.

### Fix ###
The main issue here stems from the unconditional increment for `signature->arity`, even after reporting a maximum-parameter error. Thus, `validateNumParameters` now returns a Boolean flag indicating whether or not an error was reported (even if it was from similar errors previously reported in the same parsing phase). If an error had been reported, we set the arity to -1.
This has two purposes:
1) It resets the arity once more, preventing any future increments from causing its value to increase (let alone without bound).
2) It indicates to `validateNumParameters` that an error has been reported to silence it from reporting further errors in the same parsing phase.


### Testing ###
- All tests pass (ran test script: util/test.py).
- ASAN no longer reports the buffer overflow when running the provided C + Wren test harness (I personally confirmed the overflow by using ASAN).