### PR TITLE
Fix Horspool shift table size in wrenStringFind

### DIFF
--- a/src/vm/wren_value.c
+++ b/src/vm/wren_value.c
@@ -914,13 +914,13 @@ uint32_t wrenStringFind(ObjString* haystack, ObjString* needle, uint32_t start)
   // determine how far the search window can be advanced if that character is
   // the last character in the haystack where we are searching for the needle
   // and the needle doesn't match there.
-  uint32_t shift[UINT8_MAX];
+  uint32_t shift[UINT8_MAX+1];
   uint32_t needleEnd = needle->length - 1;
 
   // By default, we assume the character is not the needle at all. In that case
   // case, if a match fails on that character, we can advance one whole needle
   // width since.
-  for (uint32_t index = 0; index < UINT8_MAX; index++)
+  for (uint32_t index = 0; index <= UINT8_MAX; index++)
   {
     shift[index] = needle->length;
   }

--- a/test/core/string/index_of.wren
+++ b/test/core/string/index_of.wren
@@ -22,3 +22,7 @@ System.print("a\0b\0c".indexOf("a")) // expect: 0
 System.print("a\0b\0c".indexOf("b\0c")) // expect: 2
 System.print("a\0b\0c".indexOf("a\0b\0c\0d")) // expect: -1
 System.print("a\0b\0a\0b".indexOf("a\0b")) // expect: 0
+
+// Byte 0xFF exercises shift[255]; the bug was OOB (ASan catches; release may still pass).
+System.print("\xff".indexOf("x")) // expect: -1
+System.print("xx\xff".indexOf("ab")) // expect: -1


### PR DESCRIPTION
## Summary

- Allocate `shift[UINT8_MAX + 1]` so every byte value 0–255 has a table entry; the previous `shift[UINT8_MAX]` array only had 255 elements (indices 0–254), so `shift[(uint8_t)c]` could read past the end when `c == 0xFF`.
- Initialize entries `0..UINT8_MAX` inclusive.
- Add `indexOf` tests involving byte `0xFF` (documented: ASan catches the OOB; release output may still look correct due to UB).

## Testing

```
python3 util/test.py core/string/index_of
```
