### PR TITLE
Return from addConstant when constant limit is exceeded

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -523,6 +523,7 @@ static int addConstant(Compiler* compiler, Value constant)
   {
     error(compiler, "A function may only contain %d unique constants.",
           MAX_CONSTANTS);
+    return -1;
   }
 
   return compiler->fn->constants.count - 1;


### PR DESCRIPTION
## Summary

In `addConstant`, when `MAX_CONSTANTS` is exceeded we call `error()` but previously did not return. Execution then fell through to `return compiler->fn->constants.count - 1`, which could emit bytecode with a bogus constant index.

Return `-1` after reporting the error (consistent with other failure paths in the compiler).

## Testing

```
python3 util/test.py limit
make -C projects/make.mac
```
