### PR TITLE
Return null from Num.fromString when strtod parses nothing

### DIFF
--- a/src/vm/wren_core.c
+++ b/src/vm/wren_core.c
@@ -617,6 +617,7 @@ DEF_PRIMITIVE(num_fromString)
   errno = 0;
   char* end;
   double number = strtod(string->value, &end);
+  if (end == string->value) RETURN_NULL;
 
   // Skip past any trailing whitespace.
   while (*end != '\0' && isspace((unsigned char)*end)) end++;

--- a/test/core/number/from_string.wren
+++ b/test/core/number/from_string.wren
@@ -11,4 +11,9 @@ System.print(Num.fromString("") == null) // expect: true
 System.print(Num.fromString("prefix1.2") == null) // expect: true
 System.print(Num.fromString("1.2suffix") == null) // expect: true
 
+// Whitespace-only: strtod performs no conversion (end == start); without an
+// early return the trailing-whitespace loop consumes the string and we
+// incorrectly return 0 instead of null.
+System.print(Num.fromString("   ") == null) // expect: true
+
 // TODO: Parse hex and scientific numbers.


### PR DESCRIPTION
## Summary

After `strtod`, if no conversion was performed, `end` is unchanged (`end == string->value` per POSIX). Return `null` immediately instead of running the trailing-whitespace and length checks on that path.

## Tests

```
python3 util/test.py core/number/from_string
```
