### PR TITLE
Parse full-range hex literals with strtoull

### DIFF
--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -750,7 +750,7 @@ static void makeNumber(Parser* parser, bool isHex)
 
   if (isHex)
   {
-    parser->next.value = NUM_VAL((double)strtoll(parser->tokenStart, NULL, 16));
+    parser->next.value = NUM_VAL((double)strtoull(parser->tokenStart, NULL, 16));
   }
   else
   {
@@ -763,7 +763,7 @@ static void makeNumber(Parser* parser, bool isHex)
     parser->next.value = NUM_VAL(0);
   }
   
-  // We don't check that the entire token is consumed after calling strtoll()
+  // We don't check that the entire token is consumed after calling strtoull()
   // or strtod() because we've already scanned it ourselves and know it's valid.
 
   makeToken(parser, TOKEN_NUMBER);

--- a/test/core/number/hex_literal_uint64_max.wren
+++ b/test/core/number/hex_literal_uint64_max.wren
@@ -1,0 +1,2 @@
+// 0xFFFFFFFFFFFFFFFF overflows signed strtoll; must parse as unsigned (strtoull).
+System.print(0xFFFFFFFFFFFFFFFF) // expect: 1.844674407371e+19


### PR DESCRIPTION
## Summary

Hex integer literals are tokenized as `0x...` and parsed with the C library. `strtoll` only covers the signed range; `0xFFFFFFFFFFFFFFFF` (UINT64_MAX) overflows, sets `ERANGE`, and the lexer incorrectly reported "Number literal was too large".

Use `strtoull` so the full 64-bit unsigned range parses, then cast to `double`.

## Regression

`test/core/number/hex_literal_uint64_max.wren`: **fails** with `strtoll` (compile error), **passes** with `strtoull`.

## Testing

```
python3 util/test.py core/number/hex_literal_uint64_max
python3 util/test.py core/number
```
